### PR TITLE
Tokenize code from files or stdin

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,23 +1,46 @@
+#include <fstream>
 #include <iostream>
 #include <memory>
-#include <ostream>
+#include <sstream>
 
 #include "reader/scanner.h"
 #include "reader/token.h"
 
-int main() {
+void print_tokens(Scanner& scanner) {
+    while (true) {
+        std::unique_ptr<Token> token = scanner.next_token();
+        if (EndOfFile* new_token = dynamic_cast<EndOfFile*>(&*token)) {
+            break;
+        }
+        std::cout << *token << std::endl;
+    }
+}
+
+void repl() {
     std::string line;
     while (std::getline(std::cin, line)) {
         std::string_view source(line);
         Scanner scanner(source);
+        print_tokens(scanner);
+    }
+}
 
-        while (true) {
-            std::unique_ptr<Token> token = scanner.next_token();
-            if (EndOfFile* new_token = dynamic_cast<EndOfFile*>(&*token)) {
-                break;
-            }
-            std::cout << *token << std::endl;
-        }
+int main(int argc, char** argv) {
+    if (argc <= 1) {
+        repl();
+        return 0;
+    }
+
+    for (int nth_file = 1; nth_file < argc; ++nth_file) {
+        std::ifstream file(argv[nth_file]);
+        std::stringstream buffer;
+        buffer << file.rdbuf();
+
+        std::string source(buffer.str());
+        Scanner scanner((std::string_view(source)));
+
+        std::cout << argv[nth_file] << ':' << std::endl;
+        print_tokens(scanner);
     }
 
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,16 +6,18 @@
 #include "reader/token.h"
 
 int main() {
-    std::string_view source(
-        "(func ; a\nfoo ; b\n(1 ; c\n2.0 'kek null -3)\ntrue) ; ; ; ; ...");
-    Scanner scanner(source);
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        std::string_view source(line);
+        Scanner scanner(source);
 
-    while (true) {
-        std::unique_ptr<Token> token = scanner.next_token();
-        if (EndOfFile* new_token = dynamic_cast<EndOfFile*>(&*token)) {
-            break;
+        while (true) {
+            std::unique_ptr<Token> token = scanner.next_token();
+            if (EndOfFile* new_token = dynamic_cast<EndOfFile*>(&*token)) {
+                break;
+            }
+            std::cout << *token << std::endl;
         }
-        std::cout << *token << std::endl;
     }
 
     return 0;


### PR DESCRIPTION
Instead of hard-coding the program text into the binary, read it from stdin line-by-line, or from files provided via command-line arguments.