### PR TITLE
Use namespaces properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 add_executable(project-f
     src/main.cpp
+    src/ast/element.cpp
+    src/ast/span.cpp
     src/reader/scanner.cpp
-    src/reader/span.cpp
     src/reader/token.cpp
     src/reader/parser.cpp
-    src/reader/element.cpp
     src/reader/reader.cpp
     src/reader/error.cpp
 )

--- a/src/ast/element.cpp
+++ b/src/ast/element.cpp
@@ -2,7 +2,7 @@
 
 #include "element.h"
 
-using namespace element;
+namespace ast {
 
 Element::Element(Span span) : span(span) {}
 
@@ -85,8 +85,9 @@ void display_element(
     stream << " at " << element.span;
 }
 
-std::ostream&
-element::operator<<(std::ostream& stream, const Element& element) {
+std::ostream& operator<<(std::ostream& stream, const Element& element) {
     display_element(stream, element, 0);
     return stream;
 }
+
+} // namespace ast

--- a/src/ast/element.h
+++ b/src/ast/element.h
@@ -8,7 +8,7 @@
 
 #include "span.h"
 
-namespace element {
+namespace ast {
 
 class Cons;
 
@@ -72,4 +72,4 @@ class Cons : public Element {
     );
 };
 
-} // namespace element
+} // namespace ast

--- a/src/ast/span.cpp
+++ b/src/ast/span.cpp
@@ -1,5 +1,7 @@
 #include "span.h"
 
+namespace ast {
+
 Position::Position(size_t line, size_t column) : line(line), column(column) {}
 
 void Position::to_next_line() {
@@ -20,3 +22,5 @@ std::ostream& operator<<(std::ostream& stream, const Span& span) {
     stream << span.start << ".." << span.end;
     return stream;
 }
+
+} // namespace ast

--- a/src/ast/span.h
+++ b/src/ast/span.h
@@ -4,6 +4,8 @@
 #include <ostream>
 #include <string>
 
+namespace ast {
+
 class Position {
   public:
     size_t line;
@@ -27,3 +29,5 @@ class Span {
 
     friend std::ostream& operator<<(std::ostream& stream, const Span& span);
 };
+
+} // namespace ast

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,9 +5,12 @@
 #include <ostream>
 #include <sstream>
 
+#include "ast/span.h"
 #include "reader/error.h"
 #include "reader/reader.h"
 #include "reader/scanner.h"
+
+using ast::Position;
 
 void print_tokens(Scanner& scanner) {
     while (true) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,9 @@
 #include "reader/scanner.h"
 
 using ast::Position;
+using reader::Reader;
+using reader::Scanner;
+using reader::SyntaxError;
 
 void print_tokens(Scanner& scanner) {
     while (true) {

--- a/src/reader/error.cpp
+++ b/src/reader/error.cpp
@@ -1,5 +1,7 @@
 #include "error.h"
 
+namespace reader {
+
 SyntaxError::SyntaxError(ErrorCause cause, ast::Span span, bool can_recover)
     : cause(cause), span(span), can_recover(can_recover) {}
 
@@ -39,3 +41,5 @@ std::ostream& operator<<(std::ostream& stream, const SyntaxError& error) {
 
     return stream;
 }
+
+} // namespace reader

--- a/src/reader/error.cpp
+++ b/src/reader/error.cpp
@@ -1,6 +1,6 @@
 #include "error.h"
 
-SyntaxError::SyntaxError(ErrorCause cause, Span span, bool can_recover)
+SyntaxError::SyntaxError(ErrorCause cause, ast::Span span, bool can_recover)
     : cause(cause), span(span), can_recover(can_recover) {}
 
 std::ostream& operator<<(std::ostream& stream, const SyntaxError& error) {

--- a/src/reader/error.h
+++ b/src/reader/error.h
@@ -2,7 +2,7 @@
 
 #include <iostream>
 
-#include "span.h"
+#include "../ast/span.h"
 
 enum class ErrorCause {
     MissingNumber,
@@ -17,10 +17,10 @@ enum class ErrorCause {
 
 class SyntaxError : public std::exception {
   public:
-    SyntaxError(ErrorCause cause, Span span, bool can_recover);
+    SyntaxError(ErrorCause cause, ast::Span span, bool can_recover);
 
     ErrorCause cause;
-    Span span;
+    ast::Span span;
     bool can_recover;
 
     friend std::ostream&

--- a/src/reader/error.h
+++ b/src/reader/error.h
@@ -4,6 +4,8 @@
 
 #include "../ast/span.h"
 
+namespace reader {
+
 enum class ErrorCause {
     MissingNumber,
     MissingFractionalPart,
@@ -26,3 +28,5 @@ class SyntaxError : public std::exception {
     friend std::ostream&
     operator<<(std::ostream& stream, const SyntaxError& error);
 };
+
+} // namespace reader

--- a/src/reader/parser.cpp
+++ b/src/reader/parser.cpp
@@ -1,13 +1,12 @@
-#include "parser.h"
-#include "element.h"
-#include "error.h"
-#include "scanner.h"
-#include "span.h"
 #include <algorithm>
 #include <exception>
 #include <memory>
 
-using namespace element;
+#include "../ast/span.h"
+#include "error.h"
+#include "parser.h"
+
+using namespace ast;
 
 Parser::Parser(Scanner scanner) : scanner(scanner) {}
 

--- a/src/reader/parser.h
+++ b/src/reader/parser.h
@@ -3,14 +3,14 @@
 #include <memory>
 #include <vector>
 
-#include "element.h"
+#include "../ast/element.h"
 #include "scanner.h"
 
 class Parser {
   public:
     Parser(Scanner scanner);
 
-    std::vector<std::unique_ptr<element::Element>> parse();
+    std::vector<std::unique_ptr<ast::Element>> parse();
 
   private:
     Scanner scanner;
@@ -18,6 +18,6 @@ class Parser {
 
     std::unique_ptr<token::Token>& peek_token();
     std::unique_ptr<token::Token> next_token();
-    std::unique_ptr<element::Element> parse_cons();
-    std::unique_ptr<element::Element> parse_element();
+    std::unique_ptr<ast::Element> parse_cons();
+    std::unique_ptr<ast::Element> parse_element();
 };

--- a/src/reader/parser.h
+++ b/src/reader/parser.h
@@ -6,6 +6,8 @@
 #include "../ast/element.h"
 #include "scanner.h"
 
+namespace reader {
+
 class Parser {
   public:
     Parser(Scanner scanner);
@@ -14,10 +16,12 @@ class Parser {
 
   private:
     Scanner scanner;
-    std::unique_ptr<token::Token> peeked = nullptr;
+    std::unique_ptr<Token> peeked = nullptr;
 
-    std::unique_ptr<token::Token>& peek_token();
-    std::unique_ptr<token::Token> next_token();
+    std::unique_ptr<Token>& peek_token();
+    std::unique_ptr<Token> next_token();
     std::unique_ptr<ast::Element> parse_cons();
     std::unique_ptr<ast::Element> parse_element();
 };
+
+} // namespace reader

--- a/src/reader/reader.cpp
+++ b/src/reader/reader.cpp
@@ -1,12 +1,11 @@
 #include "reader.h"
 #include "parser.h"
 #include "scanner.h"
-#include "span.h"
 
-Reader::Reader(std::string_view source, Position position)
+Reader::Reader(std::string_view source, ast::Position position)
     : source(source), position(position) {}
 
-std::vector<std::unique_ptr<element::Element>> Reader::read() {
+std::vector<std::unique_ptr<ast::Element>> Reader::read() {
     Scanner scanner(this->source, this->position);
     Parser parser(scanner);
     return parser.parse();

--- a/src/reader/reader.cpp
+++ b/src/reader/reader.cpp
@@ -2,6 +2,8 @@
 #include "parser.h"
 #include "scanner.h"
 
+namespace reader {
+
 Reader::Reader(std::string_view source, ast::Position position)
     : source(source), position(position) {}
 
@@ -10,3 +12,5 @@ std::vector<std::unique_ptr<ast::Element>> Reader::read() {
     Parser parser(scanner);
     return parser.parse();
 }
+
+} // namespace reader

--- a/src/reader/reader.h
+++ b/src/reader/reader.h
@@ -4,15 +4,16 @@
 #include <string_view>
 #include <vector>
 
-#include "element.h"
+#include "../ast/element.h"
+#include "../ast/span.h"
 
 class Reader {
   public:
-    Reader(std::string_view source, Position position = Position());
+    Reader(std::string_view source, ast::Position position = ast::Position());
 
-    std::vector<std::unique_ptr<element::Element>> read();
+    std::vector<std::unique_ptr<ast::Element>> read();
 
   private:
     std::string_view source;
-    Position position = Position();
+    ast::Position position;
 };

--- a/src/reader/reader.h
+++ b/src/reader/reader.h
@@ -7,6 +7,8 @@
 #include "../ast/element.h"
 #include "../ast/span.h"
 
+namespace reader {
+
 class Reader {
   public:
     Reader(std::string_view source, ast::Position position = ast::Position());
@@ -17,3 +19,5 @@ class Reader {
     std::string_view source;
     ast::Position position;
 };
+
+} // namespace reader

--- a/src/reader/scanner.cpp
+++ b/src/reader/scanner.cpp
@@ -8,7 +8,8 @@
 #include <ostream>
 #include <stdexcept>
 
-using namespace token;
+namespace reader {
+
 using ast::Position;
 using ast::Span;
 
@@ -181,3 +182,5 @@ std::unique_ptr<Token> Scanner::next_token() {
         EndOfFile(Span(this->position, this->position))
     );
 }
+
+} // namespace reader

--- a/src/reader/scanner.cpp
+++ b/src/reader/scanner.cpp
@@ -9,6 +9,8 @@
 #include <stdexcept>
 
 using namespace token;
+using ast::Position;
+using ast::Span;
 
 class ReachedEndOfFile {};
 

--- a/src/reader/scanner.h
+++ b/src/reader/scanner.h
@@ -3,23 +3,23 @@
 #include <memory>
 #include <string_view>
 
+#include "../ast/span.h"
 #include "error.h"
-#include "span.h"
 #include "token.h"
 
 class Scanner {
   public:
-    Scanner(std::string_view source, Position offset);
+    Scanner(std::string_view source, ast::Position offset);
 
     std::unique_ptr<token::Token> next_token();
 
   private:
     std::string_view source;
-    Position position;
+    ast::Position position;
 
     bool can_peek(size_t at = 0) const;
     char peek(size_t at = 0) const;
-    Span advance(size_t by = 1);
+    ast::Span advance(size_t by = 1);
 
     std::unique_ptr<token::Token> parse_symbol();
     std::unique_ptr<token::Token> parse_numeral();

--- a/src/reader/scanner.h
+++ b/src/reader/scanner.h
@@ -7,11 +7,13 @@
 #include "error.h"
 #include "token.h"
 
+namespace reader {
+
 class Scanner {
   public:
     Scanner(std::string_view source, ast::Position offset);
 
-    std::unique_ptr<token::Token> next_token();
+    std::unique_ptr<Token> next_token();
 
   private:
     std::string_view source;
@@ -21,7 +23,9 @@ class Scanner {
     char peek(size_t at = 0) const;
     ast::Span advance(size_t by = 1);
 
-    std::unique_ptr<token::Token> parse_symbol();
-    std::unique_ptr<token::Token> parse_numeral();
+    std::unique_ptr<Token> parse_symbol();
+    std::unique_ptr<Token> parse_numeral();
     SyntaxError make_literal_error(ErrorCause cause);
 };
+
+} // namespace reader

--- a/src/reader/token.cpp
+++ b/src/reader/token.cpp
@@ -5,7 +5,7 @@
 
 using namespace token;
 
-Token::Token(Span span) : span(span) {}
+Token::Token(ast::Span span) : span(span) {}
 
 bool Token::is_left_parenthesis() const {
     return dynamic_cast<const LeftParenthesis*>(this) != nullptr;

--- a/src/reader/token.cpp
+++ b/src/reader/token.cpp
@@ -3,7 +3,7 @@
 
 #include "token.h"
 
-using namespace token;
+namespace reader {
 
 Token::Token(ast::Span span) : span(span) {}
 
@@ -55,7 +55,7 @@ bool Token::is_end_of_file() const {
     return dynamic_cast<const EndOfFile*>(this) != nullptr;
 }
 
-std::ostream& token::operator<<(std::ostream& stream, const Token& token) {
+std::ostream& operator<<(std::ostream& stream, const Token& token) {
     if (token.is_left_parenthesis()) {
         stream << "LeftParenthesis";
     } else if (token.is_right_parenthesis()) {
@@ -78,3 +78,5 @@ std::ostream& token::operator<<(std::ostream& stream, const Token& token) {
 
     return stream;
 }
+
+} // namespace reader

--- a/src/reader/token.h
+++ b/src/reader/token.h
@@ -7,7 +7,7 @@
 
 #include "../ast/span.h"
 
-namespace token {
+namespace reader {
 
 class Token {
   public:
@@ -79,4 +79,4 @@ class EndOfFile : public Token {
     using Token::Token;
 };
 
-} // namespace token
+} // namespace reader

--- a/src/reader/token.h
+++ b/src/reader/token.h
@@ -5,15 +5,15 @@
 #include <ostream>
 #include <string_view>
 
-#include "span.h"
+#include "../ast/span.h"
 
 namespace token {
 
 class Token {
   public:
-    Span span;
+    ast::Span span;
 
-    Token(Span span);
+    Token(ast::Span span);
 
     virtual ~Token() = default;
 
@@ -42,28 +42,29 @@ class Identifier : public Token {
   public:
     std::string_view value;
 
-    Identifier(std::string_view value, Span span) : Token(span), value(value) {}
+    Identifier(std::string_view value, ast::Span span)
+        : Token(span), value(value) {}
 };
 
 class Integer : public Token {
   public:
     int64_t value;
 
-    Integer(int64_t value, Span span) : Token(span), value(value) {}
+    Integer(int64_t value, ast::Span span) : Token(span), value(value) {}
 };
 
 class Real : public Token {
   public:
     double value;
 
-    Real(double value, Span span) : Token(span), value(value) {}
+    Real(double value, ast::Span span) : Token(span), value(value) {}
 };
 
 class Boolean : public Token {
   public:
     bool value;
 
-    Boolean(bool value, Span span) : Token(span), value(value) {}
+    Boolean(bool value, ast::Span span) : Token(span), value(value) {}
 };
 
 class Apostrophe : public Token {


### PR DESCRIPTION
This MR defines two namespaces: `ast` and `reader`. `ast` contains all AST-related stuff, while the `reader` namespace contains all reader-related stuff.