### PR TITLE
Switch between modes on the CLI

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,3 +1,3 @@
 CompileFlags:
-  Add: [-std=c++17, -Wall]
+  Add: [-std=c++20, -Wall]
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,9 +46,15 @@ void print_ast(Reader& reader) {
     }
 }
 
-void repl() {
-    Evaluator evaluator;
+void process(Evaluator& evaluator, Reader& reader) {
+    auto elements = reader.read();
+    auto program = Program::from_elements(std::move(elements));
+    auto output = evaluator.evaluate(std::move(program));
 
+    std::cout << *output << std::endl;
+}
+
+void repl(Evaluator& evaluator) {
     std::string line;
     size_t nth_line = 0;
     while (true) {
@@ -60,11 +66,7 @@ void repl() {
         ++nth_line;
         std::string_view source(line);
         Reader reader((std::string_view(source)), Position(nth_line));
-        auto elements = reader.read();
-        auto program = Program::from_elements(std::move(elements));
-        auto result = evaluator.evaluate(std::move(program));
-
-        std::cout << *result << std::endl;
+        process(evaluator, reader);
     }
 }
 
@@ -74,8 +76,10 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    Evaluator evaluator;
+
     if (argc == 1) {
-        repl();
+        repl(evaluator);
         return 0;
     }
 
@@ -86,8 +90,7 @@ int main(int argc, char** argv) {
 
     std::string source(buffer.str());
     Reader reader((std::string_view(source)));
-
-    print_ast(reader);
+    process(evaluator, reader);
 
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,22 +69,25 @@ void repl() {
 }
 
 int main(int argc, char** argv) {
-    if (argc <= 1) {
+    if (argc > 2) {
+        std::cerr << "Error: too many arguments" << std::endl;
+        return 1;
+    }
+
+    if (argc == 1) {
         repl();
         return 0;
     }
 
-    for (int nth_file = 1; nth_file < argc; ++nth_file) {
-        std::ifstream file(argv[nth_file]);
-        std::stringstream buffer;
-        buffer << file.rdbuf();
+    char* file_name = argv[1];
+    std::ifstream file(file_name);
+    std::stringstream buffer;
+    buffer << file.rdbuf();
 
-        std::string source(buffer.str());
-        Reader reader((std::string_view(source)));
+    std::string source(buffer.str());
+    Reader reader((std::string_view(source)));
 
-        std::cout << argv[nth_file] << ':' << std::endl;
-        print_ast(reader);
-    }
+    print_ast(reader);
 
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -202,7 +202,13 @@ void process(
     }
 }
 
-void repl(Mode mode, Evaluator& evaluator) {
+void repl(Mode mode) {
+    if (mode == Mode::Auto) {
+        mode = Mode::PrintResult;
+    }
+
+    Evaluator evaluator;
+
     std::string line;
     size_t nth_line = 0;
     while (true) {
@@ -215,6 +221,21 @@ void repl(Mode mode, Evaluator& evaluator) {
         std::string_view source(line);
         process(mode, evaluator, std::string_view(source), Position(nth_line));
     }
+}
+
+void file(Mode mode, std::string_view path) {
+    if (mode == Mode::Auto) {
+        mode = Mode::Silent;
+    }
+
+    std::ifstream file((std::string(path)));
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+
+    std::string source(buffer.str());
+
+    Evaluator evaluator;
+    process(mode, evaluator, std::string_view(source), Position());
 }
 
 int main(int argc, const char** argv) {
@@ -231,25 +252,10 @@ int main(int argc, const char** argv) {
         return 0;
     }
 
-    Evaluator evaluator;
-
     if (arguments.file) {
-        if (arguments.mode == Mode::Auto) {
-            arguments.mode = Mode::Silent;
-        }
-        std::ifstream file(std::string(*arguments.file));
-        std::stringstream buffer;
-        buffer << file.rdbuf();
-
-        std::string source(buffer.str());
-        process(
-            arguments.mode, evaluator, std::string_view(source), Position()
-        );
+        file(arguments.mode, *arguments.file);
     } else {
-        if (arguments.mode == Mode::Auto) {
-            arguments.mode = Mode::PrintResult;
-        }
-        repl(arguments.mode, evaluator);
+        repl(arguments.mode);
     }
 
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -229,6 +229,10 @@ void file(Mode mode, std::string_view path) {
     }
 
     std::ifstream file((std::string(path)));
+    if (!file.is_open()) {
+        std::cerr << "Error: cannot read file " << path << std::endl;
+        return;
+    }
     std::stringstream buffer;
     buffer << file.rdbuf();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -173,28 +173,32 @@ void print_ast(std::vector<std::unique_ptr<Element>>& ast) {
 void process(
     Mode mode, Evaluator& evaluator, std::string_view source, Position position
 ) {
-    Scanner scanner(source, position);
-    if (mode == Mode::LexicalAnalysis) {
-        print_tokens(scanner);
-        return;
-    }
+    try {
+        Scanner scanner(source, position);
+        if (mode == Mode::LexicalAnalysis) {
+            print_tokens(scanner);
+            return;
+        }
 
-    Parser parser(scanner);
-    auto ast = parser.parse();
-    if (mode == Mode::SyntaxAnalysis) {
-        print_ast(ast);
-        return;
-    }
+        Parser parser(scanner);
+        auto ast = parser.parse();
+        if (mode == Mode::SyntaxAnalysis) {
+            print_ast(ast);
+            return;
+        }
 
-    auto program = Program::from_elements(std::move(ast));
-    if (mode == Mode::SemanticAnalysis) {
-        // todo: print programs
-        return;
-    }
-    auto output = evaluator.evaluate(std::move(program));
+        auto program = Program::from_elements(std::move(ast));
+        if (mode == Mode::SemanticAnalysis) {
+            // todo: print programs
+            return;
+        }
+        auto output = evaluator.evaluate(std::move(program));
 
-    if (mode == Mode::PrintResult) {
-        std::cout << *output << std::endl;
+        if (mode == Mode::PrintResult) {
+            std::cout << *output << std::endl;
+        }
+    } catch (SyntaxError error) {
+        std::cerr << error << std::endl;
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <sstream>
 
@@ -18,6 +19,133 @@ using evaluator::Program;
 using reader::Reader;
 using reader::Scanner;
 using reader::SyntaxError;
+
+enum class Mode {
+    LexicalAnalysis,
+    SyntaxAnalysis,
+    SemanticAnalysis,
+    PrintResult,
+    Silent,
+    Auto,
+};
+
+enum class ArgumentErrorCause {
+    UnknownOption,
+    ExtraArgument,
+};
+
+class ArgumentError : public std::exception {
+  public:
+    ArgumentErrorCause cause;
+    std::string_view argument;
+
+    ArgumentError(ArgumentErrorCause cause, std::string_view argument)
+        : cause(cause), argument(argument) {}
+
+    friend std::ostream&
+    operator<<(std::ostream& stream, const ArgumentError& error) {
+        stream << "Error: ";
+        switch (error.cause) {
+        case ArgumentErrorCause::UnknownOption:
+            stream << "unknown option '" << error.argument << "'";
+            break;
+        case ArgumentErrorCause::ExtraArgument:
+            stream << "extra argument '" << error.argument << "'";
+            break;
+        }
+
+        return stream;
+    }
+};
+
+class Arguments {
+    constexpr static const std::string_view HELP = "--help";
+    constexpr static const std::string_view LEXICAL = "--lexical";
+    constexpr static const std::string_view SYNTAX = "--syntax";
+    constexpr static const std::string_view SEMANTIC = "--semantic";
+    constexpr static const std::string_view PRINT = "--print";
+    constexpr static const std::string_view SILENT = "--silent";
+    constexpr static const std::string_view AUTO = "--auto";
+
+  public:
+    bool help = false;
+    Mode mode = Mode::Auto;
+    std::optional<std::string_view> file = std::nullopt;
+
+    void parse(int argc, const char** argv) {
+        bool is_parsing_options = true;
+        for (int at = 1; at < argc; ++at) {
+            std::string_view argument(argv[at]);
+
+            if (is_parsing_options && argument.starts_with('-')) {
+                if (argument == HELP) {
+                    this->help = true;
+                    break;
+                } else if (argument == "--") {
+                    is_parsing_options = false;
+                } else if (argument == LEXICAL) {
+                    this->mode = Mode::LexicalAnalysis;
+                } else if (argument == SYNTAX) {
+                    this->mode = Mode::SyntaxAnalysis;
+                } else if (argument == SEMANTIC) {
+                    this->mode = Mode::SemanticAnalysis;
+                } else if (argument == PRINT) {
+                    this->mode = Mode::PrintResult;
+                } else if (argument == SILENT) {
+                    this->mode = Mode::Silent;
+                } else if (argument == AUTO) {
+                    this->mode = Mode::Auto;
+                } else {
+                    throw ArgumentError(
+                        ArgumentErrorCause::UnknownOption, argument
+                    );
+                }
+                continue;
+            }
+
+            if (this->file) {
+                throw ArgumentError(
+                    ArgumentErrorCause::ExtraArgument, argument
+                );
+            }
+            this->file = argument;
+        }
+    }
+
+    static void print_help(const char* program_name) {
+        std::cerr << "F language interpreter" << std::endl;
+        std::cerr << std::endl;
+        std::cerr << "Usage: " << program_name << " [...options] [file]"
+                  << std::endl;
+        std::cerr << std::endl;
+        std::cerr << "Options:" << std::endl;
+        std::cerr << "\t" << HELP << "\t\tPrint this message" << std::endl;
+        std::cerr << "\t" << LEXICAL
+                  << "\tTokenize the source code and print the "
+                     "tokens. Do not process it further"
+                  << std::endl;
+        std::cerr << "\t" << SYNTAX
+                  << "\tParse the source code and print the AST. Do "
+                     "not process it further"
+                  << std::endl;
+        std::cerr << "\t" << SEMANTIC
+                  << "\tParse the AST and print the program. Do "
+                     "not process it further"
+                  << std::endl;
+        std::cerr << "\t" << PRINT
+                  << "\t\tEvaluate the code and always print its "
+                     "result. This is the default mode for REPL"
+                  << std::endl;
+        std::cerr << "\t" << SILENT
+                  << "\tEvaluate the code but do not print its "
+                     "result. This is the default mode for file evaluation"
+                  << std::endl;
+        std::cerr << "\t" << AUTO
+                  << "\t\tKeep the default mode (--print for REPL and "
+                     "--silent otherwise)"
+                  << std::endl;
+    }
+};
 
 void print_tokens(Scanner& scanner) {
     while (true) {
@@ -70,27 +198,39 @@ void repl(Evaluator& evaluator) {
     }
 }
 
-int main(int argc, char** argv) {
-    if (argc > 2) {
-        std::cerr << "Error: too many arguments" << std::endl;
+int main(int argc, const char** argv) {
+    Arguments arguments;
+    try {
+        arguments.parse(argc, argv);
+    } catch (ArgumentError error) {
+        std::cerr << error << std::endl;
         return 1;
+    }
+    if (arguments.help) {
+        const char* name = argc > 0 ? argv[0] : "project-f";
+        arguments.print_help(name);
+        return 0;
     }
 
     Evaluator evaluator;
 
-    if (argc == 1) {
+    if (arguments.file) {
+        if (arguments.mode == Mode::Auto) {
+            arguments.mode = Mode::Silent;
+        }
+        std::ifstream file(std::string(*arguments.file));
+        std::stringstream buffer;
+        buffer << file.rdbuf();
+
+        std::string source(buffer.str());
+        Reader reader((std::string_view(source)));
+        process(evaluator, reader);
+    } else {
+        if (arguments.mode == Mode::Auto) {
+            arguments.mode = Mode::PrintResult;
+        }
         repl(evaluator);
-        return 0;
     }
-
-    char* file_name = argv[1];
-    std::ifstream file(file_name);
-    std::stringstream buffer;
-    buffer << file.rdbuf();
-
-    std::string source(buffer.str());
-    Reader reader((std::string_view(source)));
-    process(evaluator, reader);
 
     return 0;
 }


### PR DESCRIPTION
It's now possible to switch between different modes using these flags: `--lexical`, `--syntax`, `--semantic`, `--print`, `--silent`, and `--auto`. Also, `--help` shows a description of all these flags.

Closes #30.