### PR TITLE
Implement pretty-printing of values

### DIFF
--- a/src/ast/element.cpp
+++ b/src/ast/element.cpp
@@ -12,8 +12,8 @@ class Depth {
     Depth(size_t depth) : depth(depth) {}
 
     friend std::ostream& operator<<(std::ostream& stream, const Depth& self) {
-        for (int i = 0; i < self.depth * 2; ++i) {
-            stream << ' ';
+        for (size_t i = 0; i < self.depth; ++i) {
+            stream << "  ";
         }
         return stream;
     }

--- a/src/ast/element.h
+++ b/src/ast/element.h
@@ -10,6 +10,8 @@
 
 namespace ast {
 
+class DisplayVerbose;
+
 class Cons;
 
 class Element {
@@ -17,6 +19,7 @@ class Element {
     Span span;
 
     Element(Span span);
+    virtual ~Element() = default;
 
     bool is_null() const;
     std::optional<int64_t> to_integer() const;
@@ -25,13 +28,22 @@ class Element {
     std::optional<std::string_view> to_symbol() const;
     std::optional<Cons> to_cons() const;
 
-    virtual ~Element() = default;
+    DisplayVerbose display_verbose();
+
+  private:
+    virtual void _display_verbose(std::ostream& stream, size_t depth) const = 0;
+
     friend std::ostream&
-    operator<<(std::ostream& stream, const Element& element);
+    operator<<(std::ostream& stream, const DisplayVerbose& self);
+    friend Cons;
 };
 
 class Null : public Element {
+  public:
     using Element::Element;
+
+  private:
+    virtual void _display_verbose(std::ostream& stream, size_t depth) const;
 };
 
 class Integer : public Element {
@@ -39,6 +51,9 @@ class Integer : public Element {
     int64_t value;
 
     Integer(int64_t value, Span span);
+
+  private:
+    virtual void _display_verbose(std::ostream& stream, size_t depth) const;
 };
 
 class Real : public Element {
@@ -46,6 +61,9 @@ class Real : public Element {
     double value;
 
     Real(double value, Span span);
+
+  private:
+    virtual void _display_verbose(std::ostream& stream, size_t depth) const;
 };
 
 class Boolean : public Element {
@@ -53,6 +71,9 @@ class Boolean : public Element {
     bool value;
 
     Boolean(bool value, Span span);
+
+  private:
+    virtual void _display_verbose(std::ostream& stream, size_t depth) const;
 };
 
 class Symbol : public Element {
@@ -60,6 +81,9 @@ class Symbol : public Element {
     std::string value;
 
     Symbol(std::string value, Span span);
+
+  private:
+    virtual void _display_verbose(std::ostream& stream, size_t depth) const;
 };
 
 class Cons : public Element {
@@ -70,6 +94,20 @@ class Cons : public Element {
     Cons(
         std::shared_ptr<Element> left, std::shared_ptr<Element> right, Span span
     );
+
+  private:
+    virtual void _display_verbose(std::ostream& stream, size_t depth) const;
+};
+
+class DisplayVerbose {
+    Element* element;
+
+    DisplayVerbose(Element* element);
+
+    friend DisplayVerbose Element::display_verbose();
+
+    friend std::ostream&
+    operator<<(std::ostream& stream, const DisplayVerbose& self);
 };
 
 } // namespace ast

--- a/src/ast/element.h
+++ b/src/ast/element.h
@@ -11,6 +11,7 @@
 namespace ast {
 
 class DisplayVerbose;
+class DisplayPretty;
 
 class Cons;
 
@@ -29,12 +30,16 @@ class Element {
     std::optional<Cons> to_cons() const;
 
     DisplayVerbose display_verbose();
+    DisplayPretty display_pretty();
 
   private:
     virtual void _display_verbose(std::ostream& stream, size_t depth) const = 0;
+    virtual void _display_pretty(std::ostream& stream) const = 0;
 
     friend std::ostream&
     operator<<(std::ostream& stream, const DisplayVerbose& self);
+    friend std::ostream&
+    operator<<(std::ostream& stream, const DisplayPretty& self);
     friend Cons;
 };
 
@@ -44,6 +49,7 @@ class Null : public Element {
 
   private:
     virtual void _display_verbose(std::ostream& stream, size_t depth) const;
+    virtual void _display_pretty(std::ostream& stream) const;
 };
 
 class Integer : public Element {
@@ -54,6 +60,7 @@ class Integer : public Element {
 
   private:
     virtual void _display_verbose(std::ostream& stream, size_t depth) const;
+    virtual void _display_pretty(std::ostream& stream) const;
 };
 
 class Real : public Element {
@@ -64,6 +71,7 @@ class Real : public Element {
 
   private:
     virtual void _display_verbose(std::ostream& stream, size_t depth) const;
+    virtual void _display_pretty(std::ostream& stream) const;
 };
 
 class Boolean : public Element {
@@ -74,6 +82,7 @@ class Boolean : public Element {
 
   private:
     virtual void _display_verbose(std::ostream& stream, size_t depth) const;
+    virtual void _display_pretty(std::ostream& stream) const;
 };
 
 class Symbol : public Element {
@@ -84,6 +93,7 @@ class Symbol : public Element {
 
   private:
     virtual void _display_verbose(std::ostream& stream, size_t depth) const;
+    virtual void _display_pretty(std::ostream& stream) const;
 };
 
 class Cons : public Element {
@@ -97,6 +107,7 @@ class Cons : public Element {
 
   private:
     virtual void _display_verbose(std::ostream& stream, size_t depth) const;
+    virtual void _display_pretty(std::ostream& stream) const;
 };
 
 class DisplayVerbose {
@@ -108,6 +119,17 @@ class DisplayVerbose {
 
     friend std::ostream&
     operator<<(std::ostream& stream, const DisplayVerbose& self);
+};
+
+class DisplayPretty {
+    Element* element;
+
+    DisplayPretty(Element* element);
+
+    friend DisplayPretty Element::display_pretty();
+
+    friend std::ostream&
+    operator<<(std::ostream& stream, const DisplayPretty& self);
 };
 
 } // namespace ast

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -195,7 +195,7 @@ void process(
         auto output = evaluator.evaluate(std::move(program));
 
         if (mode == Mode::PrintResult) {
-            std::cout << output->display_verbose() << std::endl;
+            std::cout << output->display_pretty() << std::endl;
         }
     } catch (SyntaxError error) {
         std::cerr << error << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,7 +166,7 @@ void print_tokens(Scanner& scanner) {
 
 void print_ast(std::vector<std::unique_ptr<Element>>& ast) {
     for (auto& element : ast) {
-        std::cout << *element << std::endl;
+        std::cout << element->display_verbose() << std::endl;
     }
 }
 
@@ -195,7 +195,7 @@ void process(
         auto output = evaluator.evaluate(std::move(program));
 
         if (mode == Mode::PrintResult) {
-            std::cout << *output << std::endl;
+            std::cout << output->display_verbose() << std::endl;
         }
     } catch (SyntaxError error) {
         std::cerr << error << std::endl;


### PR DESCRIPTION
```
~/inno/compilers/project-f ⎇  nice-output $= $ ./project-f 
>>> true
true
>>> false
false
>>> ()
null
>>> 0.123456
0.123456
>>> -245678
-245678
```

This also supports lists and symbols, but it's not really possible to get them inside the REPL.

Closes #32.