### PR TITLE
Improve type checking

### DIFF
--- a/src/ast/element.cpp
+++ b/src/ast/element.cpp
@@ -9,14 +9,15 @@ namespace ast {
 using utils::Depth;
 using utils::to_cons;
 
-Element::Element(Span span) : span(span) {}
+Element::Element(ElementKind kind, Span span) : span(span), kind(kind) {}
 
 DisplayVerbose Element::display_verbose(size_t depth) {
     return DisplayVerbose(this, depth);
 }
 DisplayPretty Element::display_pretty() { return DisplayPretty(this); }
 
-Integer::Integer(int64_t value, Span span) : Element(span), value(value) {}
+Integer::Integer(int64_t value, Span span)
+    : Element(ElementKind::INTEGER, span), value(value) {}
 
 void Integer::_display_verbose(std::ostream& stream, size_t) const {
     stream << "Integer(" << this->value << ", " << this->span << ")";
@@ -26,7 +27,8 @@ void Integer::_display_pretty(std::ostream& stream) const {
     stream << this->value;
 }
 
-Real::Real(double value, Span span) : Element(span), value(value) {}
+Real::Real(double value, Span span)
+    : Element(ElementKind::REAL, span), value(value) {}
 
 void Real::_display_verbose(std::ostream& stream, size_t) const {
     stream << "Real(" << this->value << ", " << this->span << ")";
@@ -54,7 +56,8 @@ void Real::_display_pretty(std::ostream& stream) const {
     }
 }
 
-Boolean::Boolean(bool value, Span span) : Element(span), value(value) {}
+Boolean::Boolean(bool value, Span span)
+    : Element(ElementKind::BOOLEAN, span), value(value) {}
 
 void Boolean::_display_verbose(std::ostream& stream, size_t) const {
     auto value = this->value ? "true" : "false";
@@ -66,7 +69,8 @@ void Boolean::_display_pretty(std::ostream& stream) const {
     stream << value;
 }
 
-Symbol::Symbol(std::string value, Span span) : Element(span), value(value) {}
+Symbol::Symbol(std::string value, Span span)
+    : Element(ElementKind::SYMBOL, span), value(value) {}
 
 void Symbol::_display_verbose(std::ostream& stream, size_t) const {
     stream << "Symbol(" << this->value << ", " << this->span << ")";
@@ -75,6 +79,8 @@ void Symbol::_display_verbose(std::ostream& stream, size_t) const {
 void Symbol::_display_pretty(std::ostream& stream) const {
     stream << this->value;
 }
+
+Null::Null(Span span) : List(ElementKind::NULL_, span) {}
 
 void Null::_display_verbose(std::ostream& stream, size_t) const {
     stream << "Null(" << this->span << ")";
@@ -85,7 +91,7 @@ void Null::_display_pretty(std::ostream& stream) const { stream << "null"; }
 Cons::Cons(
     std::shared_ptr<Element> left, std::shared_ptr<List> right, Span span
 )
-    : List(span), left(left), right(right) {}
+    : List(ElementKind::CONS, span), left(left), right(right) {}
 
 void Cons::_display_verbose(std::ostream& stream, size_t depth) const {
     stream << "Cons(\n";

--- a/src/ast/element.h
+++ b/src/ast/element.h
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string>
 
+#include "kind.h"
 #include "span.h"
 
 namespace ast {
@@ -18,8 +19,9 @@ class Cons;
 class Element {
   public:
     Span span;
+    ElementKind kind;
 
-    Element(Span span);
+    Element(ElementKind kind, Span span);
     virtual ~Element() = default;
 
     DisplayVerbose display_verbose(size_t depth = 0);
@@ -86,7 +88,7 @@ class List : public Element {
 
 class Null : public List {
   public:
-    using List::List;
+    Null(Span span);
 
   private:
     virtual void _display_verbose(std::ostream& stream, size_t depth) const;

--- a/src/ast/kind.h
+++ b/src/ast/kind.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace ast {
+
+enum class ElementKind {
+    INTEGER,
+    REAL,
+    BOOLEAN,
+    SYMBOL,
+    NULL_,
+    CONS,
+    FUNCTION,
+};
+
+}

--- a/src/evaluator/expression.h
+++ b/src/evaluator/expression.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../ast/element.h"
+#include "../ast/kind.h"
 #include <memory>
 #include <vector>
 
@@ -20,8 +21,13 @@ class Expression {
     virtual std::shared_ptr<ast::Element> evaluate() const = 0;
     virtual void display(std::ostream& stream, size_t depth) const = 0;
 
-    virtual bool can_evaluate_to_function() const = 0;
-    virtual bool can_evaluate_to_boolean() const = 0;
+    // Returns in the sense "evaluating this expression will always end up
+    // calling `return`"
+    virtual bool returns() const = 0;
+    virtual bool breaks() const = 0;
+    virtual bool diverges() const;
+    virtual bool can_evaluate_to(ast::ElementKind kind) const = 0;
+    virtual bool can_break_with(ast::ElementKind kind) const = 0;
     virtual void validate_no_free_break() const = 0;
     virtual void validate_no_break_with_value() const = 0;
 };
@@ -40,12 +46,10 @@ class Parameters {
     void display(std::ostream& stream, size_t depth) const;
 };
 
-class Program;
-
 class Body {
+  public:
     std::vector<std::unique_ptr<Expression>> body;
 
-  public:
     Body(std::vector<std::unique_ptr<Expression>> body);
 
     static Body parse(std::shared_ptr<ast::List> unparsed);
@@ -54,12 +58,8 @@ class Body {
 
     void display(std::ostream& stream, size_t depth) const;
 
-    bool can_evaluate_to_function() const;
-    bool can_evaluate_to_boolean() const;
     void validate_no_free_break() const;
     void validate_no_break_with_value() const;
-
-    friend std::ostream& operator<<(std::ostream& stream, Program const& self);
 };
 
 class Program {
@@ -85,8 +85,10 @@ class Symbol : public Expression {
     virtual std::shared_ptr<ast::Element> evaluate() const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
-    virtual bool can_evaluate_to_function() const;
-    virtual bool can_evaluate_to_boolean() const;
+    virtual bool returns() const;
+    virtual bool breaks() const;
+    virtual bool can_evaluate_to(ast::ElementKind kind) const;
+    virtual bool can_break_with(ast::ElementKind kind) const;
     virtual void validate_no_free_break() const;
     virtual void validate_no_break_with_value() const;
 };
@@ -103,8 +105,10 @@ class Quote : public Expression {
     virtual std::shared_ptr<ast::Element> evaluate() const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
-    virtual bool can_evaluate_to_function() const;
-    virtual bool can_evaluate_to_boolean() const;
+    virtual bool returns() const;
+    virtual bool breaks() const;
+    virtual bool can_evaluate_to(ast::ElementKind kind) const;
+    virtual bool can_break_with(ast::ElementKind kind) const;
     virtual void validate_no_free_break() const;
     virtual void validate_no_break_with_value() const;
 };
@@ -126,8 +130,10 @@ class Setq : public Expression {
     virtual std::shared_ptr<ast::Element> evaluate() const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
-    virtual bool can_evaluate_to_function() const;
-    virtual bool can_evaluate_to_boolean() const;
+    virtual bool returns() const;
+    virtual bool breaks() const;
+    virtual bool can_evaluate_to(ast::ElementKind kind) const;
+    virtual bool can_break_with(ast::ElementKind kind) const;
     virtual void validate_no_free_break() const;
     virtual void validate_no_break_with_value() const;
 };
@@ -151,8 +157,10 @@ class Cond : public Expression {
     virtual std::shared_ptr<ast::Element> evaluate() const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
-    virtual bool can_evaluate_to_function() const;
-    virtual bool can_evaluate_to_boolean() const;
+    virtual bool returns() const;
+    virtual bool breaks() const;
+    virtual bool can_evaluate_to(ast::ElementKind kind) const;
+    virtual bool can_break_with(ast::ElementKind kind) const;
     virtual void validate_no_free_break() const;
     virtual void validate_no_break_with_value() const;
 };
@@ -169,8 +177,10 @@ class Return : public Expression {
     virtual std::shared_ptr<ast::Element> evaluate() const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
-    virtual bool can_evaluate_to_function() const;
-    virtual bool can_evaluate_to_boolean() const;
+    virtual bool returns() const;
+    virtual bool breaks() const;
+    virtual bool can_evaluate_to(ast::ElementKind kind) const;
+    virtual bool can_break_with(ast::ElementKind kind) const;
     virtual void validate_no_free_break() const;
     virtual void validate_no_break_with_value() const;
 };
@@ -187,8 +197,10 @@ class Break : public Expression {
     virtual std::shared_ptr<ast::Element> evaluate() const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
-    virtual bool can_evaluate_to_function() const;
-    virtual bool can_evaluate_to_boolean() const;
+    virtual bool returns() const;
+    virtual bool breaks() const;
+    virtual bool can_evaluate_to(ast::ElementKind kind) const;
+    virtual bool can_break_with(ast::ElementKind kind) const;
     virtual void validate_no_free_break() const;
     virtual void validate_no_break_with_value() const;
 };
@@ -209,8 +221,10 @@ class Call : public Expression {
     virtual std::shared_ptr<ast::Element> evaluate() const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
-    virtual bool can_evaluate_to_function() const;
-    virtual bool can_evaluate_to_boolean() const;
+    virtual bool returns() const;
+    virtual bool breaks() const;
+    virtual bool can_evaluate_to(ast::ElementKind kind) const;
+    virtual bool can_break_with(ast::ElementKind kind) const;
     virtual void validate_no_free_break() const;
     virtual void validate_no_break_with_value() const;
 };
@@ -234,8 +248,10 @@ class Func : public Expression {
     virtual std::shared_ptr<ast::Element> evaluate() const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
-    virtual bool can_evaluate_to_function() const;
-    virtual bool can_evaluate_to_boolean() const;
+    virtual bool returns() const;
+    virtual bool breaks() const;
+    virtual bool can_evaluate_to(ast::ElementKind kind) const;
+    virtual bool can_break_with(ast::ElementKind kind) const;
     virtual void validate_no_free_break() const;
     virtual void validate_no_break_with_value() const;
 };
@@ -253,8 +269,10 @@ class Lambda : public Expression {
     virtual std::shared_ptr<ast::Element> evaluate() const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
-    virtual bool can_evaluate_to_function() const;
-    virtual bool can_evaluate_to_boolean() const;
+    virtual bool returns() const;
+    virtual bool breaks() const;
+    virtual bool can_evaluate_to(ast::ElementKind kind) const;
+    virtual bool can_break_with(ast::ElementKind kind) const;
     virtual void validate_no_free_break() const;
     virtual void validate_no_break_with_value() const;
 };
@@ -272,8 +290,10 @@ class Prog : public Expression {
     virtual std::shared_ptr<ast::Element> evaluate() const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
-    virtual bool can_evaluate_to_function() const;
-    virtual bool can_evaluate_to_boolean() const;
+    virtual bool returns() const;
+    virtual bool breaks() const;
+    virtual bool can_evaluate_to(ast::ElementKind kind) const;
+    virtual bool can_break_with(ast::ElementKind kind) const;
     virtual void validate_no_free_break() const;
     virtual void validate_no_break_with_value() const;
 };
@@ -291,8 +311,10 @@ class While : public Expression {
     virtual std::shared_ptr<ast::Element> evaluate() const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
-    virtual bool can_evaluate_to_function() const;
-    virtual bool can_evaluate_to_boolean() const;
+    virtual bool returns() const;
+    virtual bool breaks() const;
+    virtual bool can_evaluate_to(ast::ElementKind kind) const;
+    virtual bool can_break_with(ast::ElementKind kind) const;
     virtual void validate_no_free_break() const;
     virtual void validate_no_break_with_value() const;
 };

--- a/src/evaluator/expression/body.cpp
+++ b/src/evaluator/expression/body.cpp
@@ -48,16 +48,6 @@ void Body::display(std::ostream& stream, size_t depth) const {
     stream << Depth(depth) << ']';
 }
 
-bool Body::can_evaluate_to_function() const {
-    return this->body.size() > 0 &&
-           this->body.back()->can_evaluate_to_function();
-}
-
-bool Body::can_evaluate_to_boolean() const {
-    return this->body.size() > 0 &&
-           this->body.back()->can_evaluate_to_boolean();
-}
-
 void Body::validate_no_free_break() const {
     for (auto const& expression : this->body) {
         expression->validate_no_free_break();

--- a/src/evaluator/expression/break.cpp
+++ b/src/evaluator/expression/break.cpp
@@ -52,8 +52,14 @@ void Break::display(std::ostream& stream, size_t depth) const {
     stream << Depth(depth) << '}';
 }
 
-bool Break::can_evaluate_to_function() const { return false; }
-bool Break::can_evaluate_to_boolean() const { return false; }
+bool Break::returns() const { return this->expression->returns(); }
+bool Break::breaks() const { return !this->returns(); }
+bool Break::can_evaluate_to(ast::ElementKind) const { return false; }
+
+bool Break::can_break_with(ast::ElementKind kind) const {
+    return this->expression->can_break_with(kind) ||
+           this->expression->can_evaluate_to(kind);
+}
 
 void Break::validate_no_free_break() const {
     throw EvaluationError("`break` outside `while` or `prog`", this->span);

--- a/src/evaluator/expression/expression.cpp
+++ b/src/evaluator/expression/expression.cpp
@@ -63,4 +63,6 @@ std::unique_ptr<Expression> Expression::parse(std::shared_ptr<Element> element
     return std::make_unique<Quote>(Quote(element->span, element));
 }
 
+bool Expression::diverges() const { return this->returns() || this->breaks(); }
+
 } // namespace evaluator

--- a/src/evaluator/expression/func.cpp
+++ b/src/evaluator/expression/func.cpp
@@ -82,8 +82,12 @@ void Func::display(std::ostream& stream, size_t depth) const {
     stream << Depth(depth) << '}';
 }
 
-bool Func::can_evaluate_to_function() const { return true; }
-bool Func::can_evaluate_to_boolean() const { return false; }
+bool Func::returns() const { return false; }
+bool Func::breaks() const { return false; }
+bool Func::can_evaluate_to(ast::ElementKind kind) const {
+    return kind == ast::ElementKind::FUNCTION;
+}
+bool Func::can_break_with(ast::ElementKind) const { return false; }
 void Func::validate_no_free_break() const {}
 void Func::validate_no_break_with_value() const {}
 

--- a/src/evaluator/expression/lambda.cpp
+++ b/src/evaluator/expression/lambda.cpp
@@ -60,8 +60,12 @@ void Lambda::display(std::ostream& stream, size_t depth) const {
     stream << Depth(depth) << '}';
 }
 
-bool Lambda::can_evaluate_to_function() const { return true; }
-bool Lambda::can_evaluate_to_boolean() const { return false; }
+bool Lambda::returns() const { return false; }
+bool Lambda::breaks() const { return false; }
+bool Lambda::can_evaluate_to(ast::ElementKind kind) const {
+    return kind == ast::ElementKind::FUNCTION;
+}
+bool Lambda::can_break_with(ast::ElementKind) const { return false; }
 void Lambda::validate_no_free_break() const {}
 void Lambda::validate_no_break_with_value() const {}
 

--- a/src/evaluator/expression/prog.cpp
+++ b/src/evaluator/expression/prog.cpp
@@ -56,14 +56,33 @@ void Prog::display(std::ostream& stream, size_t depth) const {
     stream << Depth(depth) << '}';
 }
 
-bool Prog::can_evaluate_to_function() const {
-    return this->body.can_evaluate_to_function();
+bool Prog::returns() const {
+    for (auto const& expression : this->body.body) {
+        if (expression->returns()) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
-bool Prog::can_evaluate_to_boolean() const {
-    return this->body.can_evaluate_to_boolean();
+bool Prog::breaks() const { return false; }
+
+bool Prog::can_evaluate_to(ast::ElementKind kind) const {
+    for (auto const& expression : this->body.body) {
+        if (expression->can_break_with(kind)) {
+            return true;
+        }
+        if (expression->diverges()) {
+            return false;
+        }
+    }
+
+    return this->body.body.size() > 0 &&
+           this->body.body.back()->can_evaluate_to(kind);
 }
 
+bool Prog::can_break_with(ast::ElementKind) const { return false; }
 void Prog::validate_no_free_break() const {}
 void Prog::validate_no_break_with_value() const {}
 

--- a/src/evaluator/expression/quote.cpp
+++ b/src/evaluator/expression/quote.cpp
@@ -45,10 +45,12 @@ void Quote::display(std::ostream& stream, size_t depth) const {
     stream << Depth(depth) << '}';
 }
 
-bool Quote::can_evaluate_to_function() const { return false; }
-bool Quote::can_evaluate_to_boolean() const {
-    return bool(std::dynamic_pointer_cast<Boolean>(this->element));
+bool Quote::returns() const { return false; }
+bool Quote::breaks() const { return false; }
+bool Quote::can_evaluate_to(ast::ElementKind kind) const {
+    return this->element->kind == kind;
 }
+bool Quote::can_break_with(ast::ElementKind) const { return false; }
 void Quote::validate_no_free_break() const {}
 void Quote::validate_no_break_with_value() const {}
 

--- a/src/evaluator/expression/return.cpp
+++ b/src/evaluator/expression/return.cpp
@@ -52,8 +52,13 @@ void Return::display(std::ostream& stream, size_t depth) const {
     stream << Depth(depth) << '}';
 }
 
-bool Return::can_evaluate_to_function() const { return false; }
-bool Return::can_evaluate_to_boolean() const { return false; }
+bool Return::returns() const { return !this->breaks(); }
+bool Return::breaks() const { return this->expression->breaks(); }
+bool Return::can_evaluate_to(ast::ElementKind) const { return false; }
+
+bool Return::can_break_with(ast::ElementKind kind) const {
+    return this->expression->can_break_with(kind);
+}
 
 void Return::validate_no_free_break() const {
     this->expression->validate_no_free_break();

--- a/src/evaluator/expression/setq.cpp
+++ b/src/evaluator/expression/setq.cpp
@@ -68,12 +68,15 @@ void Setq::display(std::ostream& stream, size_t depth) const {
     stream << Depth(depth) << '}';
 }
 
-bool Setq::can_evaluate_to_function() const {
-    return this->initializer->can_evaluate_to_function();
+bool Setq::returns() const { return this->initializer->returns(); }
+bool Setq::breaks() const { return this->initializer->breaks(); }
+
+bool Setq::can_evaluate_to(ast::ElementKind kind) const {
+    return this->initializer->can_evaluate_to(kind);
 }
 
-bool Setq::can_evaluate_to_boolean() const {
-    return this->initializer->can_evaluate_to_boolean();
+bool Setq::can_break_with(ast::ElementKind kind) const {
+    return this->initializer->can_break_with(kind);
 }
 
 void Setq::validate_no_free_break() const {

--- a/src/evaluator/expression/symbol.cpp
+++ b/src/evaluator/expression/symbol.cpp
@@ -15,8 +15,10 @@ void Symbol::display(std::ostream& stream, size_t depth) const {
     stream << this->symbol->display_verbose(depth);
 }
 
-bool Symbol::can_evaluate_to_function() const { return true; }
-bool Symbol::can_evaluate_to_boolean() const { return true; }
+bool Symbol::returns() const { return false; }
+bool Symbol::breaks() const { return false; }
+bool Symbol::can_evaluate_to(ast::ElementKind) const { return true; }
+bool Symbol::can_break_with(ast::ElementKind) const { return false; }
 void Symbol::validate_no_free_break() const {}
 void Symbol::validate_no_break_with_value() const {}
 

--- a/src/evaluator/expression/while.cpp
+++ b/src/evaluator/expression/while.cpp
@@ -22,7 +22,7 @@ While::parse(Span span, std::shared_ptr<List> arguments) {
     }
 
     auto condition = Expression::parse(cons->left);
-    if (!condition->can_evaluate_to_boolean()) {
+    if (!condition->can_evaluate_to(ast::ElementKind::BOOLEAN)) {
         throw EvaluationError(
             "a boolean is expected, but this expression will never evaluate to "
             "a boolean",
@@ -59,8 +59,12 @@ void While::display(std::ostream& stream, size_t depth) const {
     stream << Depth(depth) << '}';
 }
 
-bool While::can_evaluate_to_function() const { return false; }
-bool While::can_evaluate_to_boolean() const { return false; }
+bool While::returns() const { return this->condition->returns(); }
+bool While::breaks() const { return false; }
+bool While::can_evaluate_to(ast::ElementKind kind) const {
+    return kind == ast::ElementKind::NULL_;
+}
+bool While::can_break_with(ast::ElementKind) const { return false; }
 void While::validate_no_free_break() const {}
 void While::validate_no_break_with_value() const {}
 


### PR DESCRIPTION
Currently, the type-checker is incorrect about `break`s in `prog`:

```
[1]> (cond (prog () (break true) 1) a b)
Evaluation error at 1:7..1:31: a boolean is expected, but this expression will never evaluate to a boolean
```

Now it takes `break`s, and divergence in general, into account:

```
[1]> (cond (prog () (break true) 1) a b) 
Program [
  Cond {
    condition = Prog {
      variables = Parameters(1:13..1:15) [
      ]
...
```