### PR TITLE
Implement the baseplate for functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(internals
     src/evaluator/error.cpp
     src/evaluator/control_flow.cpp
     src/evaluator/evaluator.cpp
+    src/evaluator/function.cpp
     src/evaluator/scope.cpp
     src/reader/scanner.cpp
     src/reader/token.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(internals
     src/evaluator/evaluator.cpp
     src/evaluator/function.cpp
     src/evaluator/function/lists.cpp
+    src/evaluator/function/evaluation.cpp
     src/evaluator/scope.cpp
     src/reader/scanner.cpp
     src/reader/token.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(internals
     src/evaluator/control_flow.cpp
     src/evaluator/evaluator.cpp
     src/evaluator/function.cpp
+    src/evaluator/function/lists.cpp
     src/evaluator/scope.cpp
     src/reader/scanner.cpp
     src/reader/token.cpp

--- a/src/evaluator/evaluator.cpp
+++ b/src/evaluator/evaluator.cpp
@@ -11,6 +11,12 @@ Evaluator::Evaluator() : global(std::make_shared<Scope>(Scope(nullptr))) {
     Span nowhere(Position(0, 0), Position(0, 0));
 
     this->global->define(
+        ast::Symbol("head", nowhere), std::make_shared<HeadFunction>()
+    );
+    this->global->define(
+        ast::Symbol("tail", nowhere), std::make_shared<TailFunction>()
+    );
+    this->global->define(
         ast::Symbol("cons", nowhere), std::make_shared<ConsFunction>()
     );
 }

--- a/src/evaluator/evaluator.cpp
+++ b/src/evaluator/evaluator.cpp
@@ -1,10 +1,19 @@
 #include "evaluator.h"
+#include "function.h"
 
 namespace evaluator {
 
 using ast::Element;
+using ast::Position;
+using ast::Span;
 
-Evaluator::Evaluator(): global(std::make_shared<Scope>(Scope(nullptr))) {}
+Evaluator::Evaluator() : global(std::make_shared<Scope>(Scope(nullptr))) {
+    Span nowhere(Position(0, 0), Position(0, 0));
+
+    this->global->define(
+        ast::Symbol("cons", nowhere), std::make_shared<ConsFunction>()
+    );
+}
 
 std::shared_ptr<Element> Evaluator::evaluate(Program program) {
     return program.evaluate(this->global);

--- a/src/evaluator/evaluator.cpp
+++ b/src/evaluator/evaluator.cpp
@@ -19,6 +19,10 @@ Evaluator::Evaluator() : global(std::make_shared<Scope>(Scope(nullptr))) {
     this->global->define(
         ast::Symbol("cons", nowhere), std::make_shared<ConsFunction>()
     );
+
+    this->global->define(
+        ast::Symbol("eval", nowhere), std::make_shared<EvalFunction>()
+    );
 }
 
 std::shared_ptr<Element> Evaluator::evaluate(Program program) {

--- a/src/evaluator/function.cpp
+++ b/src/evaluator/function.cpp
@@ -1,0 +1,40 @@
+#include "function.h"
+
+namespace evaluator {
+
+using ast::Element;
+using ast::ElementKind;
+using ast::Position;
+using ast::Span;
+
+CallFrame::CallFrame(
+    std::vector<std::shared_ptr<Element>> arguments,
+    Span call_site,
+    std::shared_ptr<Scope> caller_scope
+)
+    : arguments(std::move(arguments)), call_site(call_site),
+      caller_scope(caller_scope) {}
+
+Function::Function(ast::Span span) : Element(ElementKind::FUNCTION, span) {}
+
+void Function::_display_pretty(std::ostream& stream) const {
+    auto name = this->name();
+    stream << "#(";
+    if (name == "") {
+        stream << "lambda";
+    } else {
+        stream << "func " << name;
+    }
+    stream << " (";
+    this->display_parameters(stream);
+    stream << ") ...)";
+}
+
+BuiltInFunction::BuiltInFunction()
+    : Function(Span(Position(0, 0), Position(0, 0))) {}
+
+void BuiltInFunction::_display_verbose(std::ostream& stream, size_t) const {
+    stream << "BuiltInFunction(" << this->name() << ", " << this->span << ")";
+}
+
+} // namespace evaluator

--- a/src/evaluator/function.h
+++ b/src/evaluator/function.h
@@ -37,6 +37,26 @@ class BuiltInFunction : public Function {
     virtual void _display_verbose(std::ostream& stream, size_t depth) const;
 };
 
+class HeadFunction : public BuiltInFunction {
+  public:
+    using BuiltInFunction::BuiltInFunction;
+    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+
+  protected:
+    virtual std::string_view name() const;
+    virtual void display_parameters(std::ostream& stream) const;
+};
+
+class TailFunction : public BuiltInFunction {
+  public:
+    using BuiltInFunction::BuiltInFunction;
+    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+
+  protected:
+    virtual std::string_view name() const;
+    virtual void display_parameters(std::ostream& stream) const;
+};
+
 class ConsFunction : public BuiltInFunction {
   public:
     using BuiltInFunction::BuiltInFunction;

--- a/src/evaluator/function.h
+++ b/src/evaluator/function.h
@@ -1,0 +1,40 @@
+#include "../ast/element.h"
+#include "scope.h"
+#include <vector>
+
+namespace evaluator {
+
+class CallFrame {
+  public:
+    std::vector<std::shared_ptr<ast::Element>> arguments;
+    ast::Span call_site;
+    std::shared_ptr<Scope> caller_scope;
+
+    CallFrame(
+        std::vector<std::shared_ptr<ast::Element>> arguments,
+        ast::Span call_site,
+        std::shared_ptr<Scope> caller_scope
+    );
+};
+
+class Function : public ast::Element {
+  public:
+    Function(ast::Span span);
+
+    virtual std::shared_ptr<ast::Element> call(CallFrame frame) const = 0;
+
+  protected:
+    virtual std::string_view name() const = 0;
+    virtual void display_parameters(std::ostream& stream) const = 0;
+    void _display_pretty(std::ostream& stream) const;
+};
+
+class BuiltInFunction : public Function {
+  public:
+    BuiltInFunction();
+
+  private:
+    virtual void _display_verbose(std::ostream& stream, size_t depth) const;
+};
+
+} // namespace evaluator

--- a/src/evaluator/function.h
+++ b/src/evaluator/function.h
@@ -37,4 +37,14 @@ class BuiltInFunction : public Function {
     virtual void _display_verbose(std::ostream& stream, size_t depth) const;
 };
 
+class ConsFunction : public BuiltInFunction {
+  public:
+    using BuiltInFunction::BuiltInFunction;
+    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+
+  protected:
+    virtual std::string_view name() const;
+    virtual void display_parameters(std::ostream& stream) const;
+};
+
 } // namespace evaluator

--- a/src/evaluator/function.h
+++ b/src/evaluator/function.h
@@ -67,4 +67,14 @@ class ConsFunction : public BuiltInFunction {
     virtual void display_parameters(std::ostream& stream) const;
 };
 
+class EvalFunction : public BuiltInFunction {
+  public:
+    using BuiltInFunction::BuiltInFunction;
+    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+
+  protected:
+    virtual std::string_view name() const;
+    virtual void display_parameters(std::ostream& stream) const;
+};
+
 } // namespace evaluator

--- a/src/evaluator/function/evaluation.cpp
+++ b/src/evaluator/function/evaluation.cpp
@@ -1,0 +1,27 @@
+#include "../error.h"
+#include "../expression.h"
+#include "../function.h"
+
+namespace evaluator {
+
+using ast::Element;
+
+std::shared_ptr<Element> EvalFunction::call(CallFrame frame) const {
+    if (frame.arguments.size() != 1) {
+        throw EvaluationError(
+            "`eval` expects 1 argument, received " +
+                std::to_string(frame.arguments.size()),
+            frame.call_site
+        );
+    }
+
+    auto expression = Expression::parse(frame.arguments[0]);
+    return expression->evaluate(frame.caller_scope);
+}
+
+std::string_view EvalFunction::name() const { return "eval"; }
+void EvalFunction::display_parameters(std::ostream& stream) const {
+    stream << "program";
+}
+
+} // namespace evaluator

--- a/src/evaluator/function/lists.cpp
+++ b/src/evaluator/function/lists.cpp
@@ -6,6 +6,63 @@ namespace evaluator {
 using ast::Cons;
 using ast::Element;
 using ast::List;
+using ast::Null;
+
+std::shared_ptr<Element> HeadFunction::call(CallFrame frame) const {
+    if (frame.arguments.size() != 1) {
+        throw EvaluationError(
+            "`head` expects 1 argument, received " +
+                std::to_string(frame.arguments.size()),
+            frame.call_site
+        );
+    }
+    auto list = frame.arguments[0];
+
+    if (auto cons = std::dynamic_pointer_cast<Cons>(list)) {
+        return cons->left;
+    }
+
+    if (auto null = std::dynamic_pointer_cast<Null>(list)) {
+        return null;
+    }
+
+    throw EvaluationError(
+        "`cons` expects the first argument to be a list", frame.call_site
+    );
+}
+
+std::string_view HeadFunction::name() const { return "head"; }
+void HeadFunction::display_parameters(std::ostream& stream) const {
+    stream << "list";
+}
+
+std::shared_ptr<Element> TailFunction::call(CallFrame frame) const {
+    if (frame.arguments.size() != 1) {
+        throw EvaluationError(
+            "`tail` expects 1 argument, received " +
+                std::to_string(frame.arguments.size()),
+            frame.call_site
+        );
+    }
+    auto list = frame.arguments[0];
+
+    if (auto cons = std::dynamic_pointer_cast<Cons>(list)) {
+        return cons->right;
+    }
+
+    if (auto null = std::dynamic_pointer_cast<Null>(list)) {
+        return null;
+    }
+
+    throw EvaluationError(
+        "`tail` expects the first argument to be a list", frame.call_site
+    );
+}
+
+std::string_view TailFunction::name() const { return "tail"; }
+void TailFunction::display_parameters(std::ostream& stream) const {
+    stream << "list";
+}
 
 std::shared_ptr<Element> ConsFunction::call(CallFrame frame) const {
     if (frame.arguments.size() != 2) {

--- a/src/evaluator/function/lists.cpp
+++ b/src/evaluator/function/lists.cpp
@@ -1,0 +1,35 @@
+#include "../error.h"
+#include "../function.h"
+
+namespace evaluator {
+
+using ast::Cons;
+using ast::Element;
+using ast::List;
+
+std::shared_ptr<Element> ConsFunction::call(CallFrame frame) const {
+    if (frame.arguments.size() != 2) {
+        throw EvaluationError(
+            "`cons` expects 2 arguments, received " +
+                std::to_string(frame.arguments.size()),
+            frame.call_site
+        );
+    }
+
+    auto left = frame.arguments[0];
+    auto right = std::dynamic_pointer_cast<List>(frame.arguments[1]);
+    if (!right) {
+        throw EvaluationError(
+            "`cons` expects the second argument to be a list", frame.call_site
+        );
+    }
+
+    return std::make_unique<Cons>(left, right, frame.call_site);
+}
+
+std::string_view ConsFunction::name() const { return "cons"; }
+void ConsFunction::display_parameters(std::ostream& stream) const {
+    stream << "head tail";
+}
+
+} // namespace evaluator


### PR DESCRIPTION
Also implement `head`, `tail`, `cons`, and `eval` as example built-in functions.

Closes #55.

![image](https://github.com/fedor-ivn/project-f/assets/10610844/fa5dcb79-7a26-4dfe-8c3c-4f6d9acce897)
