### PR TITLE
Implement garbage collection

### DIFF
--- a/src/evaluator/control_flow.cpp
+++ b/src/evaluator/control_flow.cpp
@@ -1,4 +1,8 @@
 #include "control_flow.h"
 
-BreakControlFlow::BreakControlFlow(std::shared_ptr<Element> element)
-    : element(element){};
+namespace evaluator {
+
+BreakControlFlow::BreakControlFlow(ElementGuard element)
+    : element(std::move(element)){};
+
+}

--- a/src/evaluator/control_flow.h
+++ b/src/evaluator/control_flow.h
@@ -3,11 +3,13 @@
 
 #include "expression.h"
 
-using ast::Element;
+namespace evaluator {
 
 class BreakControlFlow {
   public:
-    std::shared_ptr<Element> element;
+    ElementGuard element;
 
-    BreakControlFlow(std::shared_ptr<Element> element);
+    BreakControlFlow(ElementGuard element);
 };
+
+} // namespace evaluator

--- a/src/evaluator/evaluator.cpp
+++ b/src/evaluator/evaluator.cpp
@@ -3,11 +3,10 @@
 
 namespace evaluator {
 
-using ast::Element;
 using ast::Position;
 using ast::Span;
 
-Evaluator::Evaluator() : global(std::make_shared<Scope>(Scope(nullptr))) {
+Evaluator::Evaluator() : global(this->garbage_collector.create_scope(nullptr)) {
     Span nowhere(Position(0, 0), Position(0, 0));
 
     this->global->define(
@@ -57,8 +56,10 @@ Evaluator::Evaluator() : global(std::make_shared<Scope>(Scope(nullptr))) {
     );
 }
 
-std::shared_ptr<Element> Evaluator::evaluate(Program program) {
-    return program.evaluate(this->global);
+ElementGuard Evaluator::evaluate(Program program) {
+    return program.evaluate(
+        EvaluationContext(&this->garbage_collector, *this->global)
+    );
 }
 
 } // namespace evaluator

--- a/src/evaluator/evaluator.h
+++ b/src/evaluator/evaluator.h
@@ -6,12 +6,13 @@
 namespace evaluator {
 
 class Evaluator {
-  std::shared_ptr<Scope> global;
+    GarbageCollector garbage_collector;
+    ScopeGuard global;
 
   public:
     Evaluator();
 
-    std::shared_ptr<ast::Element> evaluate(Program program);
+    ElementGuard evaluate(Program program);
 };
 
 } // namespace evaluator

--- a/src/evaluator/expression.h
+++ b/src/evaluator/expression.h
@@ -8,6 +8,14 @@
 
 namespace evaluator {
 
+class EvaluationContext {
+  public:
+    GarbageCollector* garbage_collector;
+    std::shared_ptr<Scope> scope;
+
+    EvaluationContext(GarbageCollector*, std::shared_ptr<Scope>);
+};
+
 class Expression {
   public:
     ast::Span span;
@@ -19,8 +27,7 @@ class Expression {
 
     virtual ~Expression() = default;
 
-    virtual std::shared_ptr<ast::Element> evaluate(std::shared_ptr<Scope> scope
-    ) const = 0;
+    virtual ElementGuard evaluate(EvaluationContext context) const = 0;
     virtual void display(std::ostream& stream, size_t depth) const = 0;
 
     // Returns in the sense "evaluating this expression will always end up
@@ -57,7 +64,7 @@ class Body {
 
     static Body parse(std::shared_ptr<ast::List> unparsed);
 
-    std::shared_ptr<ast::Element> evaluate(std::shared_ptr<Scope> scope) const;
+    ElementGuard evaluate(EvaluationContext context) const;
 
     void display(std::ostream& stream, size_t depth) const;
 
@@ -73,7 +80,7 @@ class Program {
 
     static Program parse(std::vector<std::shared_ptr<ast::Element>> elements);
 
-    std::shared_ptr<ast::Element> evaluate(std::shared_ptr<Scope> scope) const;
+    ElementGuard evaluate(EvaluationContext context) const;
 
     void display(std::ostream& stream, size_t depth) const;
     friend std::ostream& operator<<(std::ostream& stream, Program const& self);
@@ -85,8 +92,7 @@ class Symbol : public Expression {
   public:
     Symbol(std::shared_ptr<ast::Symbol> symbol);
 
-    virtual std::shared_ptr<ast::Element> evaluate(std::shared_ptr<Scope> scope
-    ) const;
+    virtual ElementGuard evaluate(EvaluationContext context) const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
     virtual bool returns() const;
@@ -106,8 +112,7 @@ class Quote : public Expression {
     static std::unique_ptr<Quote>
     parse(ast::Span span, std::shared_ptr<ast::List> arguments);
 
-    virtual std::shared_ptr<ast::Element> evaluate(std::shared_ptr<Scope> scope
-    ) const;
+    virtual ElementGuard evaluate(EvaluationContext context) const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
     virtual bool returns() const;
@@ -132,8 +137,7 @@ class Setq : public Expression {
     static std::unique_ptr<Setq>
     parse(ast::Span span, std::shared_ptr<ast::List> arguments);
 
-    virtual std::shared_ptr<ast::Element> evaluate(std::shared_ptr<Scope> scope
-    ) const;
+    virtual ElementGuard evaluate(EvaluationContext context) const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
     virtual bool returns() const;
@@ -160,8 +164,7 @@ class Cond : public Expression {
     static std::unique_ptr<Cond>
     parse(ast::Span span, std::shared_ptr<ast::List> arguments);
 
-    virtual std::shared_ptr<ast::Element> evaluate(std::shared_ptr<Scope> scope
-    ) const;
+    virtual ElementGuard evaluate(EvaluationContext context) const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
     virtual bool returns() const;
@@ -181,8 +184,7 @@ class Return : public Expression {
     static std::unique_ptr<Return>
     parse(ast::Span span, std::shared_ptr<ast::List> arguments);
 
-    virtual std::shared_ptr<ast::Element> evaluate(std::shared_ptr<Scope> scope
-    ) const;
+    virtual ElementGuard evaluate(EvaluationContext context) const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
     virtual bool returns() const;
@@ -202,8 +204,7 @@ class Break : public Expression {
     static std::unique_ptr<Break>
     parse(ast::Span span, std::shared_ptr<ast::List> arguments);
 
-    virtual std::shared_ptr<ast::Element> evaluate(std::shared_ptr<Scope> scope
-    ) const;
+    virtual ElementGuard evaluate(EvaluationContext context) const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
     virtual bool returns() const;
@@ -227,8 +228,7 @@ class Call : public Expression {
 
     static std::unique_ptr<Call> parse(std::shared_ptr<ast::Cons> arguments);
 
-    virtual std::shared_ptr<ast::Element> evaluate(std::shared_ptr<Scope> scope
-    ) const;
+    virtual ElementGuard evaluate(EvaluationContext context) const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
     virtual bool returns() const;
@@ -255,8 +255,7 @@ class Func : public Expression {
     static std::unique_ptr<Func>
     parse(ast::Span span, std::shared_ptr<ast::List> arguments);
 
-    virtual std::shared_ptr<ast::Element> evaluate(std::shared_ptr<Scope> scope
-    ) const;
+    virtual ElementGuard evaluate(EvaluationContext context) const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
     virtual bool returns() const;
@@ -277,8 +276,7 @@ class Lambda : public Expression {
     static std::unique_ptr<Lambda>
     parse(ast::Span span, std::shared_ptr<ast::List> arguments);
 
-    virtual std::shared_ptr<ast::Element> evaluate(std::shared_ptr<Scope> scope
-    ) const;
+    virtual ElementGuard evaluate(EvaluationContext context) const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
     virtual bool returns() const;
@@ -299,8 +297,7 @@ class Prog : public Expression {
     static std::unique_ptr<Prog>
     parse(ast::Span span, std::shared_ptr<ast::List> arguments);
 
-    virtual std::shared_ptr<ast::Element> evaluate(std::shared_ptr<Scope> scope
-    ) const;
+    virtual ElementGuard evaluate(EvaluationContext context) const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
     virtual bool returns() const;
@@ -321,8 +318,7 @@ class While : public Expression {
     static std::unique_ptr<While>
     parse(ast::Span span, std::shared_ptr<ast::List> arguments);
 
-    virtual std::shared_ptr<ast::Element> evaluate(std::shared_ptr<Scope> scope
-    ) const;
+    virtual ElementGuard evaluate(EvaluationContext context) const;
     virtual void display(std::ostream& stream, size_t depth) const;
 
     virtual bool returns() const;

--- a/src/evaluator/expression/break.cpp
+++ b/src/evaluator/expression/break.cpp
@@ -37,9 +37,9 @@ Break::parse(Span span, std::shared_ptr<List> arguments) {
     return std::make_unique<Break>(Break(span, std::move(expression)));
 }
 
-std::shared_ptr<Element> Break::evaluate(std::shared_ptr<Scope> scope) const {
-    auto element = this->expression->evaluate(scope);
-    throw BreakControlFlow(element);
+ElementGuard Break::evaluate(EvaluationContext context) const {
+    auto element = this->expression->evaluate(context);
+    throw BreakControlFlow(std::move(element));
 }
 
 void Break::display(std::ostream& stream, size_t depth) const {

--- a/src/evaluator/expression/cond.cpp
+++ b/src/evaluator/expression/cond.cpp
@@ -65,11 +65,10 @@ std::unique_ptr<Cond> Cond::parse(Span span, std::shared_ptr<List> arguments) {
     return std::make_unique<Cond>(std::move(cond));
 }
 
-std::shared_ptr<Element> Cond::evaluate(std::shared_ptr<Scope> scope) const {
-    auto evaluated_condition = condition->evaluate(scope);
-
+ElementGuard Cond::evaluate(EvaluationContext context) const {
+    auto evaluated_condition = condition->evaluate(context);
     auto boolean_condition =
-        std::dynamic_pointer_cast<ast::Boolean>(evaluated_condition);
+        std::dynamic_pointer_cast<ast::Boolean>(*evaluated_condition);
 
     if (!boolean_condition) {
         throw EvaluationError(
@@ -78,9 +77,9 @@ std::shared_ptr<Element> Cond::evaluate(std::shared_ptr<Scope> scope) const {
     }
 
     if (boolean_condition->value) {
-        return then->evaluate(scope);
+        return then->evaluate(context);
     }
-    return otherwise->evaluate(scope);
+    return otherwise->evaluate(context);
 }
 
 void Cond::display(std::ostream& stream, size_t depth) const {

--- a/src/evaluator/expression/expression.cpp
+++ b/src/evaluator/expression/expression.cpp
@@ -6,6 +6,11 @@ using ast::Cons;
 using ast::Element;
 using ast::Span;
 
+EvaluationContext::EvaluationContext(
+    GarbageCollector* gc, std::shared_ptr<Scope> scope
+)
+    : garbage_collector(gc), scope(scope) {}
+
 Expression::Expression(Span span) : span(span) {}
 
 std::unique_ptr<Expression> Expression::parse(std::shared_ptr<Element> element

--- a/src/evaluator/expression/func.cpp
+++ b/src/evaluator/expression/func.cpp
@@ -59,7 +59,7 @@ std::unique_ptr<Func> Func::parse(Span span, std::shared_ptr<List> arguments) {
     );
 }
 
-std::shared_ptr<Element> Func::evaluate(std::shared_ptr<Scope>) const {
+ElementGuard Func::evaluate(EvaluationContext) const {
     throw std::runtime_error("Not implemented");
 }
 

--- a/src/evaluator/expression/lambda.cpp
+++ b/src/evaluator/expression/lambda.cpp
@@ -40,7 +40,7 @@ Lambda::parse(Span span, std::shared_ptr<ast::List> arguments) {
     );
 }
 
-std::shared_ptr<ast::Element> Lambda::evaluate(std::shared_ptr<Scope>) const {
+ElementGuard Lambda::evaluate(EvaluationContext) const {
     throw std::runtime_error("Not implemented");
 }
 

--- a/src/evaluator/expression/prog.cpp
+++ b/src/evaluator/expression/prog.cpp
@@ -38,9 +38,8 @@ std::unique_ptr<Prog> Prog::parse(Span span, std::shared_ptr<List> arguments) {
     );
 }
 
-std::shared_ptr<Element> Prog::evaluate(std::shared_ptr<Scope> parent_scope
-) const {
-    auto local_scope = std::make_shared<Scope>(Scope(parent_scope));
+ElementGuard Prog::evaluate(EvaluationContext context) const {
+    auto local_scope = context.garbage_collector->create_scope(context.scope);
 
     for (auto parameter : this->variables.parameters) {
         local_scope->define(
@@ -48,16 +47,13 @@ std::shared_ptr<Element> Prog::evaluate(std::shared_ptr<Scope> parent_scope
         );
     }
 
-    std::shared_ptr<ast::Element> result = std::make_shared<Null>(this->span);
-    for (auto const& expression : this->body.body) {
-        try {
-            result = expression->evaluate(local_scope);
-        } catch (BreakControlFlow e) {
-            return e.element;
-        }
+    try {
+        return this->body.evaluate(
+            EvaluationContext(context.garbage_collector, *local_scope)
+        );
+    } catch (BreakControlFlow& e) {
+        return std::move(e.element);
     }
-
-    return result;
 };
 
 void Prog::display(std::ostream& stream, size_t depth) const {

--- a/src/evaluator/expression/program.cpp
+++ b/src/evaluator/expression/program.cpp
@@ -20,8 +20,8 @@ Program Program::parse(std::vector<std::shared_ptr<Element>> ast) {
     return Program(std::move(body));
 }
 
-std::shared_ptr<Element> Program::evaluate(std::shared_ptr<Scope> parent) const {
-    return this->program.evaluate(parent);
+ElementGuard Program::evaluate(EvaluationContext context) const {
+    return this->program.evaluate(context);
 }
 
 std::ostream& operator<<(std::ostream& stream, Program const& self) {

--- a/src/evaluator/expression/quote.cpp
+++ b/src/evaluator/expression/quote.cpp
@@ -4,7 +4,6 @@
 
 namespace evaluator {
 
-using ast::Boolean;
 using ast::Element;
 using ast::List;
 using ast::Span;
@@ -32,7 +31,9 @@ Quote::parse(Span span, std::shared_ptr<List> arguments) {
     return std::make_unique<Quote>(Quote(span, element));
 }
 
-std::shared_ptr<Element> Quote::evaluate(std::shared_ptr<Scope>) const { return this->element; }
+ElementGuard Quote::evaluate(EvaluationContext context) const {
+    return context.garbage_collector->temporary(this->element);
+}
 
 void Quote::display(std::ostream& stream, size_t depth) const {
     stream << "Quote {\n";

--- a/src/evaluator/expression/return.cpp
+++ b/src/evaluator/expression/return.cpp
@@ -36,7 +36,7 @@ Return::parse(Span span, std::shared_ptr<List> arguments) {
     return std::make_unique<Return>(Return(span, std::move(expression)));
 }
 
-std::shared_ptr<Element> Return::evaluate(std::shared_ptr<Scope>) const {
+ElementGuard Return::evaluate(EvaluationContext) const {
     throw std::runtime_error("Not implemented");
 }
 

--- a/src/evaluator/expression/setq.cpp
+++ b/src/evaluator/expression/setq.cpp
@@ -48,9 +48,9 @@ std::unique_ptr<Setq> Setq::parse(Span span, std::shared_ptr<List> arguments) {
     return std::make_unique<Setq>(Setq(span, symbol, std::move(expression)));
 }
 
-std::shared_ptr<Element> Setq::evaluate(std::shared_ptr<Scope> scope) const {
-    auto element = this->initializer->evaluate(scope);
-    scope->set_or_define(*this->variable, element);
+ElementGuard Setq::evaluate(EvaluationContext context) const {
+    auto element = this->initializer->evaluate(context);
+    context.scope->set_or_define(*this->variable, *element);
     return element;
 }
 

--- a/src/evaluator/expression/symbol.cpp
+++ b/src/evaluator/expression/symbol.cpp
@@ -2,13 +2,13 @@
 
 namespace evaluator {
 
-using ast::Element;
-
 Symbol::Symbol(std::shared_ptr<ast::Symbol> symbol)
     : Expression(symbol->span), symbol(symbol) {}
 
-std::shared_ptr<Element> Symbol::evaluate(std::shared_ptr<Scope> scope) const {
-    return scope->lookup(*this->symbol);
+ElementGuard Symbol::evaluate(EvaluationContext context) const {
+    return context.garbage_collector->temporary(
+        context.scope->lookup(*this->symbol)
+    );
 }
 
 void Symbol::display(std::ostream& stream, size_t depth) const {

--- a/src/evaluator/function.cpp
+++ b/src/evaluator/function.cpp
@@ -10,10 +10,9 @@ using ast::Span;
 CallFrame::CallFrame(
     std::vector<std::shared_ptr<Element>> arguments,
     Span call_site,
-    std::shared_ptr<Scope> caller_scope
+    EvaluationContext context
 )
-    : arguments(std::move(arguments)), call_site(call_site),
-      caller_scope(caller_scope) {}
+    : arguments(std::move(arguments)), call_site(call_site), context(context) {}
 
 Function::Function(ast::Span span) : Element(ElementKind::FUNCTION, span) {}
 

--- a/src/evaluator/function.h
+++ b/src/evaluator/function.h
@@ -1,6 +1,8 @@
-#include "../ast/element.h"
-#include "scope.h"
 #include <vector>
+
+#include "../ast/element.h"
+#include "expression.h"
+#include "scope.h"
 
 namespace evaluator {
 
@@ -8,12 +10,12 @@ class CallFrame {
   public:
     std::vector<std::shared_ptr<ast::Element>> arguments;
     ast::Span call_site;
-    std::shared_ptr<Scope> caller_scope;
+    EvaluationContext context;
 
     CallFrame(
         std::vector<std::shared_ptr<ast::Element>> arguments,
         ast::Span call_site,
-        std::shared_ptr<Scope> caller_scope
+        EvaluationContext context
     );
 };
 
@@ -21,7 +23,7 @@ class Function : public ast::Element {
   public:
     Function(ast::Span span);
 
-    virtual std::shared_ptr<ast::Element> call(CallFrame frame) const = 0;
+    virtual ElementGuard call(CallFrame frame) const = 0;
 
   protected:
     virtual std::string_view name() const = 0;
@@ -40,7 +42,7 @@ class BuiltInFunction : public Function {
 class HeadFunction : public BuiltInFunction {
   public:
     using BuiltInFunction::BuiltInFunction;
-    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+    virtual ElementGuard call(CallFrame frame) const;
 
   protected:
     virtual std::string_view name() const;
@@ -50,7 +52,7 @@ class HeadFunction : public BuiltInFunction {
 class TailFunction : public BuiltInFunction {
   public:
     using BuiltInFunction::BuiltInFunction;
-    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+    virtual ElementGuard call(CallFrame frame) const;
 
   protected:
     virtual std::string_view name() const;
@@ -60,7 +62,7 @@ class TailFunction : public BuiltInFunction {
 class ConsFunction : public BuiltInFunction {
   public:
     using BuiltInFunction::BuiltInFunction;
-    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+    virtual ElementGuard call(CallFrame frame) const;
 
   protected:
     virtual std::string_view name() const;
@@ -70,7 +72,7 @@ class ConsFunction : public BuiltInFunction {
 class EvalFunction : public BuiltInFunction {
   public:
     using BuiltInFunction::BuiltInFunction;
-    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+    virtual ElementGuard call(CallFrame frame) const;
 
   protected:
     virtual std::string_view name() const;
@@ -80,7 +82,7 @@ class EvalFunction : public BuiltInFunction {
 class EqualFunction : public BuiltInFunction {
   public:
     using BuiltInFunction::BuiltInFunction;
-    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+    virtual ElementGuard call(CallFrame frame) const;
 
   protected:
     virtual std::string_view name() const;
@@ -90,7 +92,7 @@ class EqualFunction : public BuiltInFunction {
 class NonequalFunction : public BuiltInFunction {
   public:
     using BuiltInFunction::BuiltInFunction;
-    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+    virtual ElementGuard call(CallFrame frame) const;
 
   protected:
     virtual std::string_view name() const;
@@ -100,7 +102,7 @@ class NonequalFunction : public BuiltInFunction {
 class LessFunction : public BuiltInFunction {
   public:
     using BuiltInFunction::BuiltInFunction;
-    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+    virtual ElementGuard call(CallFrame frame) const;
 
   protected:
     virtual std::string_view name() const;
@@ -110,7 +112,7 @@ class LessFunction : public BuiltInFunction {
 class LesseqFunction : public BuiltInFunction {
   public:
     using BuiltInFunction::BuiltInFunction;
-    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+    virtual ElementGuard call(CallFrame frame) const;
 
   protected:
     virtual std::string_view name() const;
@@ -120,7 +122,7 @@ class LesseqFunction : public BuiltInFunction {
 class GreaterFunction : public BuiltInFunction {
   public:
     using BuiltInFunction::BuiltInFunction;
-    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+    virtual ElementGuard call(CallFrame frame) const;
 
   protected:
     virtual std::string_view name() const;
@@ -130,7 +132,7 @@ class GreaterFunction : public BuiltInFunction {
 class GreatereqFunction : public BuiltInFunction {
   public:
     using BuiltInFunction::BuiltInFunction;
-    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+    virtual ElementGuard call(CallFrame frame) const;
 
   protected:
     virtual std::string_view name() const;
@@ -140,7 +142,7 @@ class GreatereqFunction : public BuiltInFunction {
 class AndFunction : public BuiltInFunction {
   public:
     using BuiltInFunction::BuiltInFunction;
-    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+    virtual ElementGuard call(CallFrame frame) const;
 
   protected:
     virtual std::string_view name() const;
@@ -150,7 +152,7 @@ class AndFunction : public BuiltInFunction {
 class OrFunction : public BuiltInFunction {
   public:
     using BuiltInFunction::BuiltInFunction;
-    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+    virtual ElementGuard call(CallFrame frame) const;
 
   protected:
     virtual std::string_view name() const;
@@ -160,7 +162,7 @@ class OrFunction : public BuiltInFunction {
 class XorFunction : public BuiltInFunction {
   public:
     using BuiltInFunction::BuiltInFunction;
-    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+    virtual ElementGuard call(CallFrame frame) const;
 
   protected:
     virtual std::string_view name() const;
@@ -170,7 +172,7 @@ class XorFunction : public BuiltInFunction {
 class NotFunction : public BuiltInFunction {
   public:
     using BuiltInFunction::BuiltInFunction;
-    virtual std::shared_ptr<Element> call(CallFrame frame) const;
+    virtual ElementGuard call(CallFrame frame) const;
 
   protected:
     virtual std::string_view name() const;

--- a/src/evaluator/function/comparisons.cpp
+++ b/src/evaluator/function/comparisons.cpp
@@ -7,7 +7,7 @@ namespace evaluator {
 using ast::Element;
 using ast::ElementKind;
 
-std::shared_ptr<Element> EqualFunction::call(CallFrame frame) const {
+ElementGuard EqualFunction::call(CallFrame frame) const {
     if (frame.arguments.size() != 2) {
         throw EvaluationError(
             "`equal` expects 2 arguments, received " +
@@ -45,7 +45,9 @@ std::shared_ptr<Element> EqualFunction::call(CallFrame frame) const {
         );
     }
 
-    return std::make_shared<ast::Boolean>(result, this->span);
+    return frame.context.garbage_collector->temporary(
+        std::make_shared<ast::Boolean>(result, this->span)
+    );
 }
 
 std::string_view EqualFunction::name() const { return "equal"; }
@@ -54,7 +56,7 @@ void EqualFunction::display_parameters(std::ostream& stream) const {
     stream << "a b";
 }
 
-std::shared_ptr<Element> NonequalFunction::call(CallFrame frame) const {
+ElementGuard NonequalFunction::call(CallFrame frame) const {
     if (frame.arguments.size() != 2) {
         throw EvaluationError(
             "`nonequal` expects 2 arguments, received " +
@@ -92,7 +94,9 @@ std::shared_ptr<Element> NonequalFunction::call(CallFrame frame) const {
         );
     }
 
-    return std::make_shared<ast::Boolean>(result, this->span);
+    return frame.context.garbage_collector->temporary(
+        std::make_shared<ast::Boolean>(result, this->span)
+    );
 }
 
 std::string_view NonequalFunction::name() const { return "nonequal"; }
@@ -101,7 +105,7 @@ void NonequalFunction::display_parameters(std::ostream& stream) const {
     stream << "a b";
 }
 
-std::shared_ptr<Element> LessFunction::call(CallFrame frame) const {
+ElementGuard LessFunction::call(CallFrame frame) const {
     if (frame.arguments.size() != 2) {
         throw EvaluationError(
             "`less` expects 2 arguments, received " +
@@ -139,7 +143,9 @@ std::shared_ptr<Element> LessFunction::call(CallFrame frame) const {
         );
     }
 
-    return std::make_shared<ast::Boolean>(result, this->span);
+    return frame.context.garbage_collector->temporary(
+        std::make_shared<ast::Boolean>(result, this->span)
+    );
 }
 
 std::string_view LessFunction::name() const { return "less"; }
@@ -148,7 +154,7 @@ void LessFunction::display_parameters(std::ostream& stream) const {
     stream << "a b";
 }
 
-std::shared_ptr<Element> LesseqFunction::call(CallFrame frame) const {
+ElementGuard LesseqFunction::call(CallFrame frame) const {
     if (frame.arguments.size() != 2) {
         throw EvaluationError(
             "`lesseq` expects 2 arguments, received " +
@@ -186,7 +192,9 @@ std::shared_ptr<Element> LesseqFunction::call(CallFrame frame) const {
         );
     }
 
-    return std::make_shared<ast::Boolean>(result, this->span);
+    return frame.context.garbage_collector->temporary(
+        std::make_shared<ast::Boolean>(result, this->span)
+    );
 }
 
 std::string_view LesseqFunction::name() const { return "lesseq"; }
@@ -195,7 +203,7 @@ void LesseqFunction::display_parameters(std::ostream& stream) const {
     stream << "a b";
 }
 
-std::shared_ptr<Element> GreaterFunction::call(CallFrame frame) const {
+ElementGuard GreaterFunction::call(CallFrame frame) const {
     if (frame.arguments.size() != 2) {
         throw EvaluationError(
             "`greater` expects 2 arguments, received " +
@@ -233,7 +241,9 @@ std::shared_ptr<Element> GreaterFunction::call(CallFrame frame) const {
         );
     }
 
-    return std::make_shared<ast::Boolean>(result, this->span);
+    return frame.context.garbage_collector->temporary(
+        std::make_shared<ast::Boolean>(result, this->span)
+    );
 }
 
 std::string_view GreaterFunction::name() const { return "greater"; }
@@ -242,7 +252,7 @@ void GreaterFunction::display_parameters(std::ostream& stream) const {
     stream << "a b";
 }
 
-std::shared_ptr<Element> GreatereqFunction::call(CallFrame frame) const {
+ElementGuard GreatereqFunction::call(CallFrame frame) const {
     if (frame.arguments.size() != 2) {
         throw EvaluationError(
             "`greatereq` expects 2 arguments, received " +
@@ -280,7 +290,9 @@ std::shared_ptr<Element> GreatereqFunction::call(CallFrame frame) const {
         );
     }
 
-    return std::make_shared<ast::Boolean>(result, this->span);
+    return frame.context.garbage_collector->temporary(
+        std::make_shared<ast::Boolean>(result, this->span)
+    );
 }
 
 std::string_view GreatereqFunction::name() const { return "greatereq"; }

--- a/src/evaluator/function/evaluation.cpp
+++ b/src/evaluator/function/evaluation.cpp
@@ -4,9 +4,7 @@
 
 namespace evaluator {
 
-using ast::Element;
-
-std::shared_ptr<Element> EvalFunction::call(CallFrame frame) const {
+ElementGuard EvalFunction::call(CallFrame frame) const {
     if (frame.arguments.size() != 1) {
         throw EvaluationError(
             "`eval` expects 1 argument, received " +
@@ -16,7 +14,7 @@ std::shared_ptr<Element> EvalFunction::call(CallFrame frame) const {
     }
 
     auto expression = Expression::parse(frame.arguments[0]);
-    return expression->evaluate(frame.caller_scope);
+    return expression->evaluate(frame.context);
 }
 
 std::string_view EvalFunction::name() const { return "eval"; }

--- a/src/evaluator/function/lists.cpp
+++ b/src/evaluator/function/lists.cpp
@@ -8,7 +8,7 @@ using ast::Element;
 using ast::List;
 using ast::Null;
 
-std::shared_ptr<Element> HeadFunction::call(CallFrame frame) const {
+ElementGuard HeadFunction::call(CallFrame frame) const {
     if (frame.arguments.size() != 1) {
         throw EvaluationError(
             "`head` expects 1 argument, received " +
@@ -19,11 +19,11 @@ std::shared_ptr<Element> HeadFunction::call(CallFrame frame) const {
     auto list = frame.arguments[0];
 
     if (auto cons = std::dynamic_pointer_cast<Cons>(list)) {
-        return cons->left;
+        return frame.context.garbage_collector->temporary(cons->left);
     }
 
     if (auto null = std::dynamic_pointer_cast<Null>(list)) {
-        return null;
+        return frame.context.garbage_collector->temporary(null);
     }
 
     throw EvaluationError(
@@ -36,7 +36,7 @@ void HeadFunction::display_parameters(std::ostream& stream) const {
     stream << "list";
 }
 
-std::shared_ptr<Element> TailFunction::call(CallFrame frame) const {
+ElementGuard TailFunction::call(CallFrame frame) const {
     if (frame.arguments.size() != 1) {
         throw EvaluationError(
             "`tail` expects 1 argument, received " +
@@ -47,11 +47,11 @@ std::shared_ptr<Element> TailFunction::call(CallFrame frame) const {
     auto list = frame.arguments[0];
 
     if (auto cons = std::dynamic_pointer_cast<Cons>(list)) {
-        return cons->right;
+        return frame.context.garbage_collector->temporary(cons->right);
     }
 
     if (auto null = std::dynamic_pointer_cast<Null>(list)) {
-        return null;
+        return frame.context.garbage_collector->temporary(null);
     }
 
     throw EvaluationError(
@@ -64,7 +64,7 @@ void TailFunction::display_parameters(std::ostream& stream) const {
     stream << "list";
 }
 
-std::shared_ptr<Element> ConsFunction::call(CallFrame frame) const {
+ElementGuard ConsFunction::call(CallFrame frame) const {
     if (frame.arguments.size() != 2) {
         throw EvaluationError(
             "`cons` expects 2 arguments, received " +
@@ -81,7 +81,9 @@ std::shared_ptr<Element> ConsFunction::call(CallFrame frame) const {
         );
     }
 
-    return std::make_unique<Cons>(left, right, frame.call_site);
+    return frame.context.garbage_collector->temporary(
+        std::make_unique<Cons>(left, right, frame.call_site)
+    );
 }
 
 std::string_view ConsFunction::name() const { return "cons"; }

--- a/src/evaluator/function/logical.cpp
+++ b/src/evaluator/function/logical.cpp
@@ -7,7 +7,7 @@ namespace evaluator {
 using ast::Element;
 using ast::ElementKind;
 
-std::shared_ptr<Element> AndFunction::call(CallFrame frame) const {
+ElementGuard AndFunction::call(CallFrame frame) const {
     if (frame.arguments.size() != 2) {
         throw EvaluationError(
             "`and` expects 2 arguments, received " +
@@ -30,7 +30,9 @@ std::shared_ptr<Element> AndFunction::call(CallFrame frame) const {
     auto b_bool = std::dynamic_pointer_cast<ast::Boolean>(b_element);
     auto result = a_bool->value && b_bool->value;
 
-    return std::make_shared<ast::Boolean>(result, this->span);
+    return frame.context.garbage_collector->temporary(
+        std::make_shared<ast::Boolean>(result, this->span)
+    );
 }
 
 std::string_view AndFunction::name() const { return "and"; }
@@ -39,7 +41,7 @@ void AndFunction::display_parameters(std::ostream& stream) const {
     stream << "a b";
 }
 
-std::shared_ptr<Element> OrFunction::call(CallFrame frame) const {
+ElementGuard OrFunction::call(CallFrame frame) const {
     if (frame.arguments.size() != 2) {
         throw EvaluationError(
             "`or` expects 2 arguments, received " +
@@ -62,7 +64,9 @@ std::shared_ptr<Element> OrFunction::call(CallFrame frame) const {
     auto b_bool = std::dynamic_pointer_cast<ast::Boolean>(b_element);
     auto result = a_bool->value || b_bool->value;
 
-    return std::make_shared<ast::Boolean>(result, this->span);
+    return frame.context.garbage_collector->temporary(
+        std::make_shared<ast::Boolean>(result, this->span)
+    );
 }
 
 std::string_view OrFunction::name() const { return "or"; }
@@ -71,7 +75,7 @@ void OrFunction::display_parameters(std::ostream& stream) const {
     stream << "a b";
 }
 
-std::shared_ptr<Element> XorFunction::call(CallFrame frame) const {
+ElementGuard XorFunction::call(CallFrame frame) const {
     if (frame.arguments.size() != 2) {
         throw EvaluationError(
             "`xor` expects 2 arguments, received " +
@@ -94,7 +98,9 @@ std::shared_ptr<Element> XorFunction::call(CallFrame frame) const {
     auto b_bool = std::dynamic_pointer_cast<ast::Boolean>(b_element);
     auto result = a_bool->value != b_bool->value;
 
-    return std::make_shared<ast::Boolean>(result, this->span);
+    return frame.context.garbage_collector->temporary(
+        std::make_shared<ast::Boolean>(result, this->span)
+    );
 }
 
 std::string_view XorFunction::name() const { return "xor"; }
@@ -103,7 +109,7 @@ void XorFunction::display_parameters(std::ostream& stream) const {
     stream << "a b";
 }
 
-std::shared_ptr<Element> NotFunction::call(CallFrame frame) const {
+ElementGuard NotFunction::call(CallFrame frame) const {
     if (frame.arguments.size() != 1) {
         throw EvaluationError(
             "`not` expects 1 argument, received " +
@@ -123,7 +129,9 @@ std::shared_ptr<Element> NotFunction::call(CallFrame frame) const {
     auto element_bool = std::dynamic_pointer_cast<ast::Boolean>(element);
     auto result = !element_bool->value;
 
-    return std::make_shared<ast::Boolean>(result, this->span);
+    return frame.context.garbage_collector->temporary(
+        std::make_shared<ast::Boolean>(result, this->span)
+    );
 }
 
 std::string_view NotFunction::name() const { return "not"; }

--- a/src/evaluator/scope.cpp
+++ b/src/evaluator/scope.cpp
@@ -24,7 +24,9 @@ Scope* Scope::find_scope(ast::Symbol const& symbol) {
     return nullptr;
 }
 
-void Scope::set_or_define(ast::Symbol const& symbol, std::shared_ptr<ast::Element> value) {
+void Scope::set_or_define(
+    ast::Symbol const& symbol, std::shared_ptr<ast::Element> value
+) {
     if (auto found = this->find_scope(symbol)) {
         found->define(symbol, value);
         return;
@@ -43,5 +45,67 @@ std::shared_ptr<ast::Element> Scope::lookup(ast::Symbol const& symbol) {
         "variable `" + symbol.value + "` is not defined", symbol.span
     );
 }
+
+GarbageCollector::GarbageCollector() {}
+
+ScopeGuard GarbageCollector::create_scope(std::shared_ptr<Scope> parent) {
+    // For `std::make_shared`, `Scope`'s constructor is private 🤡, so keep
+    // using the copy constructor here.
+    auto scope = std::make_shared<Scope>(Scope(parent));
+    this->alive_scopes.insert(scope);
+    return ScopeGuard(this, scope);
+}
+
+ElementGuard GarbageCollector::temporary(std::shared_ptr<ast::Element> value) {
+    this->temporaries.insert(value);
+    return ElementGuard(this, value);
+}
+
+void GarbageCollector::collect() {
+    // todo: must keep scopes which are held by functions still reachable
+    // via alive scopes and temporaries
+    this->dead_scopes.clear();
+}
+
+ScopeGuard::ScopeGuard(GarbageCollector* gc, std::shared_ptr<Scope> scope)
+    : garbage_collector(gc), scope(scope) {}
+
+ScopeGuard::~ScopeGuard() {
+    if (!this->garbage_collector) {
+        return;
+    }
+
+    this->garbage_collector->dead_scopes.insert(this->scope);
+    this->garbage_collector->alive_scopes.erase(this->scope);
+}
+
+std::shared_ptr<Scope> ScopeGuard::operator*() { return this->scope; }
+std::shared_ptr<Scope> ScopeGuard::operator->() { return this->scope; }
+
+ElementGuard::ElementGuard(
+    GarbageCollector* gc, std::shared_ptr<ast::Element> element
+)
+    : garbage_collector(gc), element(element) {}
+
+ElementGuard::~ElementGuard() {
+    if (!this->garbage_collector) {
+        return;
+    }
+
+    this->garbage_collector->temporaries.erase(this->element);
+    if (this->collect_garbage) {
+        this->garbage_collector->collect();
+    }
+}
+
+std::shared_ptr<ast::Element> ElementGuard::operator*() {
+    return this->element;
+}
+
+std::shared_ptr<ast::Element> ElementGuard::operator->() {
+    return this->element;
+}
+
+void ElementGuard::deactivate() { this->collect_garbage = false; }
 
 } // namespace evaluator

--- a/src/evaluator/scope.h
+++ b/src/evaluator/scope.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "../ast/element.h"
 
@@ -12,13 +13,76 @@ class Scope {
     std::unordered_map<std::string, std::shared_ptr<ast::Element>> variables;
     std::shared_ptr<Scope> parent;
 
-  public:
     Scope(std::shared_ptr<Scope> parent);
-    void define(ast::Symbol const& symbol, std::shared_ptr<ast::Element> value);
-    void set_or_define(ast::Symbol const& symbol, std::shared_ptr<ast::Element> value);
+
     // Find the scope where the variable was defined.
     Scope* find_scope(ast::Symbol const& symbol);
+
+  public:
+    void define(ast::Symbol const& symbol, std::shared_ptr<ast::Element> value);
+    void set_or_define(
+        ast::Symbol const& symbol, std::shared_ptr<ast::Element> value
+    );
     std::shared_ptr<ast::Element> lookup(ast::Symbol const& symbol);
+
+    friend class GarbageCollector;
 };
 
-} // namespace scope
+class ScopeGuard;
+class ElementGuard;
+
+class GarbageCollector {
+    std::unordered_set<std::shared_ptr<Scope>> alive_scopes;
+    std::unordered_set<std::shared_ptr<Scope>> dead_scopes;
+    std::unordered_set<std::shared_ptr<ast::Element>> temporaries;
+
+  public:
+    GarbageCollector();
+
+    ScopeGuard create_scope(std::shared_ptr<Scope> parent);
+    ElementGuard temporary(std::shared_ptr<ast::Element> value);
+
+    void collect();
+
+    friend class ScopeGuard;
+    friend class ElementGuard;
+};
+
+class ScopeGuard {
+    GarbageCollector* garbage_collector;
+    std::shared_ptr<Scope> scope;
+
+    ScopeGuard(GarbageCollector*, std::shared_ptr<Scope>);
+
+  public:
+    ScopeGuard(ScopeGuard const&) = delete;
+    ScopeGuard(ScopeGuard&&) = default;
+    ~ScopeGuard();
+    std::shared_ptr<Scope> operator*();
+    std::shared_ptr<Scope> operator->();
+
+    friend class GarbageCollector;
+};
+
+class ElementGuard {
+    GarbageCollector* garbage_collector;
+    std::shared_ptr<ast::Element> element;
+    bool collect_garbage = true;
+
+    ElementGuard(GarbageCollector*, std::shared_ptr<ast::Element>);
+
+  public:
+    ElementGuard(ElementGuard const&) = delete;
+    ElementGuard(ElementGuard&&) = default;
+    ~ElementGuard();
+    std::shared_ptr<ast::Element> operator*();
+    std::shared_ptr<ast::Element> operator->();
+
+    // Still protect the element, but don't try to collect garbage when
+    // destroyed
+    void deactivate();
+
+    friend class GarbageCollector;
+};
+
+} // namespace evaluator

--- a/src/test_runner.cpp
+++ b/src/test_runner.cpp
@@ -136,7 +136,7 @@ bool test_semantic_file(std::filesystem::path path) {
 
     auto output = evaluator.evaluate(std::move(program));
 
-    auto boolean = std::dynamic_pointer_cast<ast::Boolean>(output);
+    auto boolean = std::dynamic_pointer_cast<ast::Boolean>(*output);
 
     if (!boolean) {
         return false;


### PR DESCRIPTION
While reference counting does a good job cleaning the memory up right now, a problem will arise when we implement user-defined functions. On one hand, the user-defined function has access to the outer scope, so it must keep a pointer to it. On the other hand, this function will likely be stored as a variable in some scope, so the scope must keep a pointer to that function. A cycle arises: a function keeps a pointer to its parent scope, and that parent scope also keeps a pointer to this function.  This is a problem for memory management: how do we know when we can drop the scope together with the function? With `shared_ptr` used everywhere, even if there ceases to be a way to access the function, `shared_ptr` will keep the function and the scope alive: the function has a pointer to the scope, so the scope remains, and the scope has a pointer to the function, so the function remains.

When such a cycle arises, `weak_ptr` is needed. It allows one to keep a pointer to an object, but lets it be destroyed when all strong pointers are destroyed. This break the cycle and the memory will be cleaned up, but there's one problem: it will be cleaned up too early. If `weak_ptr` is used to keep a pointer to the parent scope of a function, when we leave that scope, it will be destroyed and the function loses its parent scope.

To fix this problem, we introduce a garbage collector. The garbage collector will be aware of all scopes and keep them alive by storing a strong pointer to them. Now, even when using `weak_ptr` to store a pointer to a function's parent scope, everything is fine because the garbage collector keeps this pointer alive. Now we only need to find out which scopes may be destroyed safely. 

A scope can be either alive or dead. If a scope is dead, the only thing that may keep it alive is a user-defined function. The global scope is alive for the duration of the program; various scopes created during program execution remain alive while execution is inside this scope. For example, one may not delete the scope where `foo` is defined while `prog` is being executed, because `x` is still available and that lambda captured `foo`:

```lisp
(prog ()
    (setq x (prog (foo) (lambda (..) ..)))
    ; ...
    )
```

To keep track when a scope becomes dead, we introduce `ScopeGuard`. When we ask the garbage collector for a new scope, it will make one and return it behind a `ScopeGuard`. While this guard is alive, the scope is alive. When the guard is destroyed (e.g. `prog` execution reached the end, but also because `return` is propagating through the call stack), the guard marks its scope dead. It may also want to collect garbage at this stage.

...and that presents another problem: if we return a function from the `prog`, the garbage collector might destroy its parent scope. To prevent this from happening, the garbage collector also keeps track of all temporary values: they're not in any scope, but someone still has access to it, so it must not be affected. This is done via `ElementGuard`, which is returned from all special forms now.

Finally, when the garbage collector runs, it inspects all alive scopes and temporaries, looking for dead scopes that are still captured by reachable user-defined functions. Such scopes are retained, and other dead scopes are forgotten. No other management is required on our side: we just help `shared_ptr` to keep alive what has to be kept alive, but after that, `shared_ptr` can clean up memory on its own.

---

Technically, we don't have user-defined functions now and the garbage collector is not needed right now. But I had nothing to do, so I decided to prepare the basement for it now (currently, the GC does basically nothing). It turned out to be pretty instrusive, so it's actually better to merge it sooner than later.

Closes #59.