### PR TITLE
Fix zero division

### DIFF
--- a/src/evaluator/function/arithmetic.cpp
+++ b/src/evaluator/function/arithmetic.cpp
@@ -146,12 +146,7 @@ ElementGuard DivideFunction::call(CallFrame frame) const {
                 }
                 return a / b;
             },
-            [&frame](double a, double b) {
-                if (b == 0) {
-                    throw EvaluationError("division by zero", frame.call_site);
-                }
-                return a / b;
-            }
+            [](double a, double b) { return a / b; }
         )) {
         return frame.context.garbage_collector->temporary(element);
     }


### PR DESCRIPTION
Some tests have failed due to check for zero divider. In this PR, I removed this check allowing the results to be some sort of `NaN`.